### PR TITLE
HOTFIX: CD 파이프라인 제한시간 증가

### DIFF
--- a/.github/workflows/prod_deploy.yml
+++ b/.github/workflows/prod_deploy.yml
@@ -25,3 +25,4 @@ jobs:
           npm install
           npm run build
           pm2 start npm --name "sulmun2yong" -- run start
+      timeout-minutes: 40


### PR DESCRIPTION
## 📢 설명
- CD 파이프라인 타임아웃 제한을 40분으로 수정

## ✅ 체크 리스트
- [ ] CD 파이프라인이 잘 작동하는지 확인
