### PR TITLE
[SBL-122] 임시용 설문 결과 페이지 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "next": "14.2.4",
         "react": "^18",
         "react-dom": "^18",
+        "react-google-charts": "^4.0.1",
         "react-icons": "^5.2.1",
         "react-toastify": "^10.0.5"
       },
@@ -4823,6 +4824,15 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-google-charts": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/react-google-charts/-/react-google-charts-4.0.1.tgz",
+      "integrity": "sha512-V/hcMcNuBgD5w49BYTUDye+bUKaPmsU5vy/9W/Nj2xEeGn+6/AuH9IvBkbDcNBsY00cV9OeexdmgfI5RFHgsXQ==",
+      "peerDependencies": {
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
       }
     },
     "node_modules/react-icons": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "next": "14.2.4",
     "react": "^18",
     "react-dom": "^18",
+    "react-google-charts": "^4.0.1",
     "react-icons": "^5.2.1",
     "react-toastify": "^10.0.5"
   },

--- a/src/app/(main)/result/[surveyId]/page.tsx
+++ b/src/app/(main)/result/[surveyId]/page.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { Chart } from 'react-google-charts';
+import { useEffect, useState } from 'react';
+import { getResults } from '../../../../services/result/fetch';
+import type { Results } from './type';
+
+export default function Page({ params }: { params: { surveyId: string } }) {
+  const { surveyId } = params;
+  const [data, setData] = useState<Results | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        const response = await getResults({ surveyId });
+        setData(response);
+      } catch (err) {
+        setError('설문 결과를 불러오는데 실패했습니다.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [surveyId]);
+
+  if (loading) return <div>Loading...</div>;
+  if (error) return <div>{error}</div>;
+
+  return (
+    <div>
+      {data?.results.map((result) => {
+        const chartData = [
+          ['Content', 'Count'],
+          ...result.responses.map((response) => [response.content, response.count]),
+        ];
+
+        return (
+          <div key={result.questionId}>
+            <Chart
+              chartType="PieChart" // 추후 차트 유형 선택 가능하도록 수정
+              data={chartData}
+              options={{ /* 추후 다른 옵션 추가 */ title: `ID가 "${result.questionId}"인 질문의 응답` }}
+              width="600px"
+              height="400px"
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/services/result/fetch.ts
+++ b/src/services/result/fetch.ts
@@ -1,0 +1,10 @@
+import { kyWrapper } from '../ky-wrapper';
+import { makeUrl } from '../utils';
+import type { Results } from './types';
+
+const getResults = async ({ surveyId }: { surveyId: string }) => {
+  const URL = makeUrl(['surveys', 'result', surveyId]);
+  return kyWrapper.get<Results>(URL);
+};
+
+export { getResults };

--- a/src/services/result/types.ts
+++ b/src/services/result/types.ts
@@ -1,0 +1,15 @@
+interface Results {
+  results: Result[];
+}
+
+interface Result {
+  questionId: string;
+  responses: Response[];
+}
+
+interface Response {
+  content: string;
+  count: number;
+}
+
+export type { Results };


### PR DESCRIPTION
## 📢 설명
![image](https://github.com/user-attachments/assets/2fcdb73b-4231-447f-af98-721aec3cfda0)
- 임시용 설문 결과 페이지 구현

## ✅ 체크 리스트
- [ ] 백엔드 개발자에게 설문 maker 바꿔달라고 요청하기
- [ ] http://localhost:3000/result/a35b6a9b-a6d9-e509-1588-8bc276c9d3ea 해당 링크 들어갔을 때 설문의 결과가 잘 보이는지 확인
