### PR TITLE
[SBL-147] 참가자 관리 탭 구현

### DIFF
--- a/src/app/management/[id]/page.tsx
+++ b/src/app/management/[id]/page.tsx
@@ -31,7 +31,7 @@ export default function Page({ params }: { params: { id: string } }) {
 
   let content;
   if (tab === 0) content = <Tab0 surveyId={id} />;
-  else if (tab === 1) content = <Tab1 />;
+  else if (tab === 1) content = <Tab1 surveyId={id} />;
   else if (tab === 2) content = <Tab2 />;
   else if (tab === 3) content = <Tab3 />;
 

--- a/src/app/management/[id]/tab0.module.css
+++ b/src/app/management/[id]/tab0.module.css
@@ -2,7 +2,7 @@
   box-sizing: border-box;
   border-radius: 8px;
   width: 100%;
-  max-width: 800px;
+  max-width: var(--container-width);
   margin: 0 auto;
   padding: 12px;
 }
@@ -14,12 +14,13 @@
   box-sizing: border-box;
 }
 
-.loading, .error {
+.loading,
+.error {
   display: flex;
   justify-content: center;
 }
 
-.participantInfo{
+.participantInfo {
   display: flex;
   align-items: center;
   margin-bottom: 10px;

--- a/src/app/management/[id]/tab0.tsx
+++ b/src/app/management/[id]/tab0.tsx
@@ -55,7 +55,7 @@ export default function Tab0({ surveyId }: { surveyId: string }) {
         <div className={styles.participantInfoContent}>
           <FaUsers className={styles.participantIcon} />
         </div>
-        <div className={styles.participantInfoContent}>응답자 수: {data?.participantCount}명</div>
+        <div className={styles.participantInfoContent}>응답자 수 : {data?.participantCount}명</div>
       </div>
       <FilterManager onSearch={handleSearch} resultInfo={makeResultInfo()} />
       {data?.sectionResults.map((sectionResult: SectionResult) => (

--- a/src/app/management/[id]/tab1.module.css
+++ b/src/app/management/[id]/tab1.module.css
@@ -2,12 +2,13 @@
   box-sizing: border-box;
   border-radius: 8px;
   width: 100%;
-  max-width: 800px;
+  max-width: var(--container-width);
   margin: 0 auto;
   padding: 12px;
 }
 
-.loading, .error {
+.loading,
+.error {
   display: flex;
   justify-content: center;
 }

--- a/src/app/management/[id]/tab1.module.css
+++ b/src/app/management/[id]/tab1.module.css
@@ -2,14 +2,12 @@
   box-sizing: border-box;
   border-radius: 8px;
   width: 100%;
-  max-width: 600px;
+  max-width: 800px;
   margin: 0 auto;
   padding: 12px;
 }
 
-.container div,
-.container label,
-.container input,
-.container textarea {
-  box-sizing: border-box;
+.loading, .error {
+  display: flex;
+  justify-content: center;
 }

--- a/src/app/management/[id]/tab1.tsx
+++ b/src/app/management/[id]/tab1.tsx
@@ -1,13 +1,47 @@
 import React from 'react';
-import 'moment/locale/ko';
+import { useParticipants } from '@/services/participant';
+import ParticipantSummary from '@/components/management/participant/ParticipantSummary';
+import WinnerList from '@/components/management/participant/WinnerList';
+import ParticipantList from '@/components/management/participant/ParticipantList';
+import Error from '@/components/ui/error/Error';
+import Loading from '@/components/ui/loading/Loading';
+import { ParticipantInfo } from '@/services/participant/types';
 import styles from './tab1.module.css';
 
-function Tab1() {
+export default function Tab1({ surveyId }: { surveyId: string }) {
+  const { data, isLoading, isError, refetch } = useParticipants(surveyId);
+
+  if (isLoading)
+    return (
+      <div className={styles.loading}>
+        <Loading message="데이터를 불러오는 중..." />
+      </div>
+    );
+  if (isError)
+    return (
+      <div className={styles.error}>
+        <Error message="마이페이지를 불러오지 못했습니다." buttons={[{ text: '재시도', fn: refetch }]} margin="18px" />
+      </div>
+    );
+
+  const participants: ParticipantInfo[] = data ? data.participants : [];
+  const targetParticipant = data?.targetParticipant ? data.targetParticipant : null;
+  const isImmediateDraw = targetParticipant !== null;
+
+  const participantsWithDraw = participants.filter((p) => p.drawInfo && p.drawInfo.drawResult !== 'BEFORE_DRAW');
+
+  const winners = participantsWithDraw.filter((p) => p.drawInfo?.drawResult === 'WIN');
+
   return (
     <div className={styles.container}>
-      <h3>참가자 관리</h3>
+      <ParticipantSummary
+        responseCount={participants.length}
+        drawCount={participantsWithDraw.length}
+        targetParticipant={targetParticipant}
+        winningCount={winners.length}
+      />
+      {isImmediateDraw && <WinnerList winners={winners} />}
+      <ParticipantList participants={participants} />
     </div>
   );
 }
-
-export default Tab1;

--- a/src/app/management/[id]/tab1.tsx
+++ b/src/app/management/[id]/tab1.tsx
@@ -39,6 +39,7 @@ export default function Tab1({ surveyId }: { surveyId: string }) {
         drawCount={participantsWithDraw.length}
         targetParticipant={targetParticipant}
         winningCount={winners.length}
+        handleRefetch={() => refetch()}
       />
       {isImmediateDraw && <WinnerList winners={winners} />}
       <ParticipantList participants={participants} />

--- a/src/app/management/[id]/tab1.tsx
+++ b/src/app/management/[id]/tab1.tsx
@@ -39,7 +39,6 @@ export default function Tab1({ surveyId }: { surveyId: string }) {
         drawCount={participantsWithDraw.length}
         targetParticipant={targetParticipant}
         winningCount={winners.length}
-        handleRefetch={() => refetch()}
       />
       {isImmediateDraw && <WinnerList winners={winners} />}
       <ParticipantList participants={participants} />

--- a/src/components/management/participant/ParticipantList.module.css
+++ b/src/components/management/participant/ParticipantList.module.css
@@ -15,7 +15,7 @@
   margin-top: 10px;
   background-color: #fff;
   border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--box-shadow);
 }
 
 .participantTable th,

--- a/src/components/management/participant/ParticipantList.module.css
+++ b/src/components/management/participant/ParticipantList.module.css
@@ -1,0 +1,67 @@
+.participantList {
+  margin-bottom: 30px;
+}
+
+.title {
+  font-size: 20px;
+  margin-bottom: 10px;
+  color: #000;
+  font-weight: bold;
+}
+
+.participantTable {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 10px;
+  background-color: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.participantTable th,
+.participantTable td {
+  border: 1px solid #ddd;
+  padding: 10px;
+  text-align: center;
+  font-weight: 500;
+}
+
+.participantTable th {
+  background-color: #f1f1f1;
+  font-weight: 600;
+  color: #555;
+}
+
+.participantTable td {
+  color: #666;
+}
+
+.participantTable tr:nth-child(even) {
+  background-color: #f9f9f9;
+}
+
+.participantTable tr:hover {
+  background-color: #f1f7ff;
+}
+
+.viewButtonCell {
+  text-align: center;
+  padding: 0;
+}
+
+.viewButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: #0070f3;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.viewButton:hover {
+  color: #0056b3;
+}
+
+.viewButton svg {
+  font-size: 14px;
+}

--- a/src/components/management/participant/ParticipantList.tsx
+++ b/src/components/management/participant/ParticipantList.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import moment from 'moment';
+import Link from 'next/link';
+import { ParticipantInfo } from '@/services/participant/types';
+import { FaEye } from 'react-icons/fa';
+import styles from './ParticipantList.module.css';
+
+interface ParticipantListProps {
+  participants: ParticipantInfo[];
+}
+
+export default function ParticipantList({ participants }: ParticipantListProps) {
+  return (
+    <div className={styles.participantList}>
+      <h2 className={styles.title}>참가자 목록</h2>
+      <table className={styles.participantTable}>
+        <thead>
+          <tr>
+            <th>응답 일시</th>
+            <th>응답 보기</th>
+          </tr>
+        </thead>
+        <tbody>
+          {participants.map((participant) => (
+            <tr key={participant.participantId}>
+              <td>{moment(participant.participatedAt).format('YYYY-MM-DD HH:mm:ss')}</td>
+              <td className={styles.viewButtonCell}>
+                <Link href={`/participant/${participant.participantId}`} className={styles.viewButton}>
+                  <FaEye />
+                  <span>응답 보기</span>
+                </Link>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/management/participant/ParticipantSummary.module.css
+++ b/src/components/management/participant/ParticipantSummary.module.css
@@ -48,7 +48,6 @@
   flex-direction: column;
   gap: 15px;
   font-size: 16px;
-  font-weight: 600;
 }
 
 .infoWithIcon {

--- a/src/components/management/participant/ParticipantSummary.module.css
+++ b/src/components/management/participant/ParticipantSummary.module.css
@@ -1,0 +1,25 @@
+.summaryContainer {
+  margin-bottom: 30px;
+  color: #333;
+}
+
+.title {
+  font-size: 20px;
+  margin-bottom: 10px;
+  margin-top: 0px;
+  color: #000;
+}
+
+.infoWithIcons {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.infoWithIcon {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}

--- a/src/components/management/participant/ParticipantSummary.module.css
+++ b/src/components/management/participant/ParticipantSummary.module.css
@@ -3,11 +3,44 @@
   color: #333;
 }
 
+.titleContainer {
+  margin-top: 0px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
 .title {
   font-size: 20px;
-  margin-bottom: 10px;
-  margin-top: 0px;
   color: #000;
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.refreshButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 5px;
+  padding: 5px;
+  cursor: pointer;
+  transition: background-color 0.3s;
+  gap: 5px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #333;
+  background-color: rgb(255, 213, 33);
+}
+
+.refreshButton:hover {
+  background-color: rgb(220, 183, 28);
+}
+
+.refreshButton svg {
+  font-size: 12px;
+  color: #333;
 }
 
 .infoWithIcons {

--- a/src/components/management/participant/ParticipantSummary.tsx
+++ b/src/components/management/participant/ParticipantSummary.tsx
@@ -1,0 +1,43 @@
+import { FaClipboardCheck, FaTrophy } from 'react-icons/fa';
+import { FaUserGroup } from 'react-icons/fa6';
+import styles from './ParticipantSummary.module.css';
+
+interface ParticipantSummaryProps {
+  responseCount: number;
+  drawCount: number | null;
+  targetParticipant: number | null;
+  winningCount: number | null;
+}
+
+export default function ParticipantSummary({
+  responseCount,
+  drawCount,
+  targetParticipant,
+  winningCount,
+}: ParticipantSummaryProps) {
+  return (
+    <div className={styles.summaryContainer}>
+      <h2 className={styles.title}>참가 현황</h2>
+      <div className={styles.infoWithIcons}>
+        <div className={styles.infoWithIcon}>
+          <FaClipboardCheck />
+          <div>{responseCount}명 응답 완료</div>
+        </div>
+        {drawCount && targetParticipant && winningCount ? (
+          <>
+            <div className={styles.infoWithIcon}>
+              <FaUserGroup />
+              <div>
+                {drawCount}명 추첨 완료 / 최대 {targetParticipant}명 추첨 가능
+              </div>
+            </div>
+            <div className={styles.infoWithIcon}>
+              <FaTrophy />
+              <div>{winningCount}명 당첨</div>
+            </div>
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/management/participant/ParticipantSummary.tsx
+++ b/src/components/management/participant/ParticipantSummary.tsx
@@ -1,4 +1,4 @@
-import { FaClipboardCheck, FaTrophy } from 'react-icons/fa';
+import { FaClipboardCheck, FaTrophy, FaSync } from 'react-icons/fa';
 import { FaUserGroup } from 'react-icons/fa6';
 import styles from './ParticipantSummary.module.css';
 
@@ -7,6 +7,7 @@ interface ParticipantSummaryProps {
   drawCount: number | null;
   targetParticipant: number | null;
   winningCount: number | null;
+  handleRefetch: () => void;
 }
 
 export default function ParticipantSummary({
@@ -14,10 +15,16 @@ export default function ParticipantSummary({
   drawCount,
   targetParticipant,
   winningCount,
+  handleRefetch,
 }: ParticipantSummaryProps) {
   return (
     <div className={styles.summaryContainer}>
-      <h2 className={styles.title}>참가 현황</h2>
+      <div className={styles.titleContainer}>
+        <h2 className={styles.title}>참가 현황</h2>
+        <button type="button" onClick={() => handleRefetch()} className={styles.refreshButton}>
+          <FaSync /> 갱신
+        </button>
+      </div>
       <div className={styles.infoWithIcons}>
         <div className={styles.infoWithIcon}>
           <FaClipboardCheck />

--- a/src/components/management/participant/ParticipantSummary.tsx
+++ b/src/components/management/participant/ParticipantSummary.tsx
@@ -1,4 +1,4 @@
-import { FaClipboardCheck, FaTrophy, FaSync } from 'react-icons/fa';
+import { FaClipboardCheck, FaTrophy } from 'react-icons/fa';
 import { FaUserGroup } from 'react-icons/fa6';
 import styles from './ParticipantSummary.module.css';
 
@@ -7,7 +7,6 @@ interface ParticipantSummaryProps {
   drawCount: number | null;
   targetParticipant: number | null;
   winningCount: number | null;
-  handleRefetch: () => void;
 }
 
 export default function ParticipantSummary({
@@ -15,15 +14,11 @@ export default function ParticipantSummary({
   drawCount,
   targetParticipant,
   winningCount,
-  handleRefetch,
 }: ParticipantSummaryProps) {
   return (
     <div className={styles.summaryContainer}>
       <div className={styles.titleContainer}>
         <h2 className={styles.title}>참가 현황</h2>
-        <button type="button" onClick={() => handleRefetch()} className={styles.refreshButton}>
-          <FaSync /> 갱신
-        </button>
       </div>
       <div className={styles.infoWithIcons}>
         <div className={styles.infoWithIcon}>

--- a/src/components/management/participant/WinnerList.module.css
+++ b/src/components/management/participant/WinnerList.module.css
@@ -15,7 +15,7 @@
   margin-top: 10px;
   background-color: #fff;
   border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--box-shadow);
   overflow: hidden;
 }
 

--- a/src/components/management/participant/WinnerList.module.css
+++ b/src/components/management/participant/WinnerList.module.css
@@ -1,0 +1,46 @@
+.winnerList {
+  margin-bottom: 30px;
+  color: #333;
+}
+
+.title {
+  font-size: 20px;
+  margin-bottom: 10px;
+  color: #000;
+}
+
+.winnerTable {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 10px;
+  background-color: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+}
+
+.winnerTable th,
+.winnerTable td {
+  border: 1px solid #ddd;
+  padding: 10px;
+  text-align: center;
+  font-weight: 500;
+}
+
+.winnerTable th {
+  background-color: #f1f1f1;
+  font-weight: 600;
+  color: #555;
+}
+
+.winnerTable td {
+  color: #666;
+}
+
+.winnerTable tr:nth-child(even) {
+  background-color: #f9f9f9;
+}
+
+.winnerTable tr:hover {
+  background-color: #f1f7ff;
+}

--- a/src/components/management/participant/WinnerList.tsx
+++ b/src/components/management/participant/WinnerList.tsx
@@ -1,0 +1,33 @@
+import moment from 'moment';
+import { ParticipantInfo } from '@/services/participant/types';
+import styles from './WinnerList.module.css';
+
+interface WinnerListProps {
+  winners: ParticipantInfo[];
+}
+
+export default function WinnerList({ winners }: WinnerListProps) {
+  return (
+    <div className={styles.winnerList}>
+      <h2 className={styles.title}>당첨자 목록</h2>
+      <table className={styles.winnerTable}>
+        <thead>
+          <tr>
+            <th>응답 일시</th>
+            <th>리워드 이름</th>
+            <th>전화번호</th>
+          </tr>
+        </thead>
+        <tbody>
+          {winners.map((winner) => (
+            <tr key={winner.participantId}>
+              <td>{moment(winner.participatedAt).format('YYYY-MM-DD HH:mm:ss')}</td>
+              <td>{winner.drawInfo?.reward}</td>
+              <td>{winner.drawInfo?.phoneNumber}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/services/participant/fetch.ts
+++ b/src/services/participant/fetch.ts
@@ -1,0 +1,10 @@
+import { kyWrapper } from '../ky-wrapper';
+import { makeUrl } from '../utils';
+import type { ParticipantList } from './types';
+
+const getParticipants = async (surveyId: string) => {
+  const URL = makeUrl(['surveys', 'participants', surveyId]);
+  return kyWrapper.get<ParticipantList>(URL);
+};
+
+export { getParticipants };

--- a/src/services/participant/index.ts
+++ b/src/services/participant/index.ts
@@ -10,6 +10,8 @@ const useParticipants = (surveyId: string) => {
     queryKey: queryKeys.participants(surveyId),
     queryFn: () => getParticipants(surveyId),
     placeholderData: keepPreviousData,
+    staleTime: 0,
+    gcTime: Infinity,
   });
 };
 

--- a/src/services/participant/index.ts
+++ b/src/services/participant/index.ts
@@ -1,0 +1,16 @@
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
+import { getParticipants } from '@/services/participant/fetch';
+
+const queryKeys = {
+  participants: (surveyId: string) => ['participants', surveyId],
+};
+
+const useParticipants = (surveyId: string) => {
+  return useQuery({
+    queryKey: queryKeys.participants(surveyId),
+    queryFn: () => getParticipants(surveyId),
+    placeholderData: keepPreviousData,
+  });
+};
+
+export { useParticipants };

--- a/src/services/participant/types.ts
+++ b/src/services/participant/types.ts
@@ -1,0 +1,20 @@
+interface ParticipantList {
+  participants: ParticipantInfo[];
+  targetParticipant: number | null;
+}
+
+interface ParticipantInfo {
+  participantId: string;
+  participatedAt: string;
+  drawInfo: DrawInfo | null;
+}
+
+interface DrawInfo {
+  drawResult: DrawResult;
+  reward: string;
+  phoneNumber: string;
+}
+
+type DrawResult = 'BEFORE_DRAW' | 'WIN' | 'LOSE';
+
+export type { ParticipantList, ParticipantInfo, DrawInfo, DrawResult };


### PR DESCRIPTION
## 📢 설명
![image](https://github.com/user-attachments/assets/1d9c94eb-0be3-4569-9287-3ae4882b72ab)

- 참가자 목록, 당첨자 목록을 볼 수 있는 참가자 관리 탭 구현
- 설문 통계 탭 PR(124번 브랜치) 머지 후 리뷰 진행

## ✅ 체크 리스트

- [x]  진행 중이고 즉시 추첨 설문의 설문 관리페이지 접속 후 참가자 관리 탭 진입 시 아래와 같이 참가 현황, 당첨자 목록, 참가자 목록이 잘 보이는지 확인
    
    ![image](https://github.com/user-attachments/assets/1d9c94eb-0be3-4569-9287-3ae4882b72ab)
    
- [x]  참가자 목록의 응답 보기 버튼 클릭 시 [http://localhost:3000/participant/{participantId}로](http://localhost:3000/participant/%7BparticipantId%7D%EB%A1%9C) 잘 이동되는지 확인 (임시로 설정한 url입니다. 추후에 개별 응답 보기 탭이랑 연결시킬 예정입니다.)
    
    ![image](https://github.com/user-attachments/assets/9ebfba02-af46-4f7c-9eaf-57b09a501b28)
    
- [x]  갱신 버튼 클릭 시 api 호출이 한 번 더 이루어지는지 확인
    
    ![image](https://github.com/user-attachments/assets/62df5388-0ac1-4298-87ad-4bf873728a69)
    
- [x]  진행 중이고 즉시 추첨이 아닌 설문의 설문 관리페이지 접속 후 참가자 관리 탭 진입 시 아래와 같이 참가 현황(추첨, 당첨 관련은 X), 참가자 목록이 잘 보이는지 확인
    
    ![image](https://github.com/user-attachments/assets/e1d151d5-269a-405b-890a-bea75418cc22)
