### PR TITLE
[SBL-152] 개별 응답 탭과 설정 탭 구현 및 기타 사항 수정

### DIFF
--- a/src/app/(main)/mypage/page.tsx
+++ b/src/app/(main)/mypage/page.tsx
@@ -28,7 +28,7 @@ const createdMapper = (arg: MyPageSurveyInfo) => {
   return (
     <>
       <Link
-        href={['제작 중', '수정 중', '마감'].includes(arg.status) ? `/workbench/${arg.id}` : `/management/${arg.id}`}
+        href={['제작 중', '수정 중'].includes(arg.status) ? `/workbench/${arg.id}` : `/management/${arg.id}`}
         style={{ textDecoration: 'none', color: 'inherit' }}>
         <span style={{ display: 'flex', alignItems: 'center' }}>
           <Image

--- a/src/app/management/[id]/page.tsx
+++ b/src/app/management/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { ReadonlyURLSearchParams, useSearchParams } from 'next/navigation';
-import { replaceURLSearchParams } from '@/utils/url-search-params';
+import { replaceURLSearchParams, deleteURLSearchParam } from '@/utils/url-search-params';
 import { useGetSurvey } from '@/components/workbench/service';
 import Header from '@/components/management/ui/Header';
 import styles from './page.module.css';
@@ -27,6 +27,7 @@ export default function Page({ params }: { params: { id: string } }) {
   const tabHandler = (newTab: number) => {
     setTab(newTab);
     replaceURLSearchParams('tab', newTab);
+    deleteURLSearchParam('participantId');
   };
 
   let content;

--- a/src/app/management/[id]/page.tsx
+++ b/src/app/management/[id]/page.tsx
@@ -40,7 +40,7 @@ export default function Page({ params }: { params: { id: string } }) {
   if (tab === 0) content = <Tab0 surveyId={id} />;
   else if (tab === 1) content = <Tab1 surveyId={id} setTab={setTab} />;
   else if (tab === 2) content = <Tab2 surveyId={id} participantId={searchParams.get('participantId')} />;
-  else if (tab === 3) content = <Tab3 surveyId={id} isFinished={data?.status === 'CLOSED'} />;
+  else if (tab === 3) content = <Tab3 surveyId={id} initialIsFinished={data?.status === 'CLOSED'} />;
 
   return (
     <div className={styles.app}>

--- a/src/app/management/[id]/page.tsx
+++ b/src/app/management/[id]/page.tsx
@@ -5,6 +5,7 @@ import { ReadonlyURLSearchParams, useSearchParams, useRouter } from 'next/naviga
 import { replaceURLSearchParams, deleteURLSearchParam } from '@/utils/url-search-params';
 import { useGetSurvey } from '@/components/workbench/service';
 import Header from '@/components/management/ui/Header';
+import { showToast } from '@/utils/toast';
 import styles from './page.module.css';
 import Tab0 from './tab0';
 import Tab1 from './tab1';
@@ -32,7 +33,7 @@ export default function Page({ params }: { params: { id: string } }) {
   };
 
   if (data && ['NOT_STARTED', 'IN_MODIFICATION'].includes(data.status)) {
-    alert('접근할 수 없습니다.');
+    showToast('error', '접근할 수 없습니다.');
     router.push('/mypage');
   }
 

--- a/src/app/management/[id]/page.tsx
+++ b/src/app/management/[id]/page.tsx
@@ -32,7 +32,7 @@ export default function Page({ params }: { params: { id: string } }) {
   let content;
   if (tab === 0) content = <Tab0 surveyId={id} />;
   else if (tab === 1) content = <Tab1 surveyId={id} />;
-  else if (tab === 2) content = <Tab2 />;
+  else if (tab === 2) content = <Tab2 surveyId={id} participantId={searchParams.get('participantId')} />;
   else if (tab === 3) content = <Tab3 />;
 
   return (

--- a/src/app/management/[id]/page.tsx
+++ b/src/app/management/[id]/page.tsx
@@ -41,7 +41,7 @@ export default function Page({ params }: { params: { id: string } }) {
   if (tab === 0) content = <Tab0 surveyId={id} />;
   else if (tab === 1) content = <Tab1 surveyId={id} setTab={setTab} />;
   else if (tab === 2) content = <Tab2 surveyId={id} participantId={searchParams.get('participantId')} />;
-  else if (tab === 3) content = <Tab3 surveyId={id} initialIsFinished={data?.status === 'CLOSED'} />;
+  else if (tab === 3) content = <Tab3 surveyId={id} initialIsFinished={data ? data.status === 'CLOSED' : undefined} />;
 
   return (
     <div className={styles.app}>

--- a/src/app/management/[id]/page.tsx
+++ b/src/app/management/[id]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { ReadonlyURLSearchParams, useSearchParams } from 'next/navigation';
+import { ReadonlyURLSearchParams, useSearchParams, useRouter } from 'next/navigation';
 import { replaceURLSearchParams, deleteURLSearchParam } from '@/utils/url-search-params';
 import { useGetSurvey } from '@/components/workbench/service';
 import Header from '@/components/management/ui/Header';
@@ -18,6 +18,7 @@ const getTabFromSearchParams = (searchParams: ReadonlyURLSearchParams) => {
 };
 
 export default function Page({ params }: { params: { id: string } }) {
+  const router = useRouter();
   const { id } = params;
 
   const searchParams = useSearchParams();
@@ -29,6 +30,11 @@ export default function Page({ params }: { params: { id: string } }) {
     replaceURLSearchParams('tab', newTab);
     deleteURLSearchParam('participantId');
   };
+
+  if (data && ['NOT_STARTED', 'IN_MODIFICATION'].includes(data.status)) {
+    alert('접근할 수 없습니다.');
+    router.push('/mypage');
+  }
 
   let content;
   if (tab === 0) content = <Tab0 surveyId={id} />;

--- a/src/app/management/[id]/page.tsx
+++ b/src/app/management/[id]/page.tsx
@@ -34,7 +34,7 @@ export default function Page({ params }: { params: { id: string } }) {
   if (tab === 0) content = <Tab0 surveyId={id} />;
   else if (tab === 1) content = <Tab1 surveyId={id} setTab={setTab} />;
   else if (tab === 2) content = <Tab2 surveyId={id} participantId={searchParams.get('participantId')} />;
-  else if (tab === 3) content = <Tab3 />;
+  else if (tab === 3) content = <Tab3 surveyId={id} isFinished={data?.status === 'CLOSED'} />;
 
   return (
     <div className={styles.app}>

--- a/src/app/management/[id]/page.tsx
+++ b/src/app/management/[id]/page.tsx
@@ -31,7 +31,7 @@ export default function Page({ params }: { params: { id: string } }) {
 
   let content;
   if (tab === 0) content = <Tab0 surveyId={id} />;
-  else if (tab === 1) content = <Tab1 surveyId={id} />;
+  else if (tab === 1) content = <Tab1 surveyId={id} setTab={setTab} />;
   else if (tab === 2) content = <Tab2 surveyId={id} participantId={searchParams.get('participantId')} />;
   else if (tab === 3) content = <Tab3 />;
 

--- a/src/app/management/[id]/tab0.tsx
+++ b/src/app/management/[id]/tab0.tsx
@@ -11,7 +11,7 @@ import styles from './tab0.module.css';
 export default function Tab0({ surveyId }: { surveyId: string }) {
   const [resultFilter, setResultFilter] = useState<ResultFilter>({ questionFilters: [] });
   const [isManualSearch, setIsManualSearch] = useState(false);
-  const { data, isLoading, isError, refetch } = useSurveyResult(surveyId, resultFilter);
+  const { data, isLoading, isError, refetch } = useSurveyResult(surveyId, resultFilter, undefined);
 
   const handleSearch = (filters: QuestionFilter[]) => {
     setResultFilter({ questionFilters: filters });

--- a/src/app/management/[id]/tab1.tsx
+++ b/src/app/management/[id]/tab1.tsx
@@ -8,7 +8,13 @@ import Loading from '@/components/ui/loading/Loading';
 import { ParticipantInfo } from '@/services/participant/types';
 import styles from './tab1.module.css';
 
-export default function Tab1({ surveyId }: { surveyId: string }) {
+export default function Tab1({
+  surveyId,
+  setTab,
+}: {
+  surveyId: string;
+  setTab: React.Dispatch<React.SetStateAction<number>>;
+}) {
   const { data, isLoading, isError, refetch } = useParticipants(surveyId);
 
   if (isLoading)
@@ -41,7 +47,7 @@ export default function Tab1({ surveyId }: { surveyId: string }) {
         winningCount={winners.length}
       />
       {isImmediateDraw && <WinnerList winners={winners} />}
-      <ParticipantList participants={participants} />
+      <ParticipantList participants={participants} setTab={setTab} />
     </div>
   );
 }

--- a/src/app/management/[id]/tab2.module.css
+++ b/src/app/management/[id]/tab2.module.css
@@ -2,7 +2,7 @@
   box-sizing: border-box;
   border-radius: 8px;
   width: 100%;
-  max-width: 600px;
+  max-width: var(--container-width);
   margin: 0 auto;
   padding: 12px;
 }
@@ -12,4 +12,62 @@
 .container input,
 .container textarea {
   box-sizing: border-box;
+}
+
+.loading,
+.error {
+  display: flex;
+  justify-content: center;
+}
+
+.navigation {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.navButton {
+  background: rgb(255, 213, 33);
+  border: none;
+  color: #000;
+  cursor: pointer;
+  font-size: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px;
+  border-radius: 4px;
+  transition: background-color 0.3s;
+}
+
+.navButton:disabled {
+  background: #ccc;
+  cursor: not-allowed;
+}
+
+.navButton:hover:not(:disabled) {
+  background: rgb(220, 183, 28);
+}
+
+.indexInput {
+  width: 50px;
+  text-align: center;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 4px;
+}
+
+.participationDate {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 14px;
+  color: #555;
+}
+
+.calendarIcon {
+  font-size: 16px;
+  color: #0070f3;
 }

--- a/src/app/management/[id]/tab2.tsx
+++ b/src/app/management/[id]/tab2.tsx
@@ -1,13 +1,169 @@
-import React from 'react';
-import 'moment/locale/ko';
+import { useState, useEffect, useMemo } from 'react';
+import { FaArrowLeft, FaArrowRight, FaCalendarAlt } from 'react-icons/fa'; // 아이콘 추가
+import moment from 'moment';
+import type { SectionResult } from '@/services/result/types';
+import SectionResultViewer from '@/components/management/result/SectionResultViewer';
+import { useSurveyResult } from '@/services/result';
+import { useParticipants } from '@/services/participant';
+import { deleteURLSearchParam } from '@/utils/url-search-params';
+import Loading from '@/components/ui/loading/Loading';
+import Error from '@/components/ui/error/Error';
 import styles from './tab2.module.css';
 
-function Tab2() {
+export default function Tab2({ surveyId, participantId }: { surveyId: string; participantId: string | null }) {
+  const {
+    data: participantData,
+    isLoading: participantsIsLoading,
+    isError: participantsIsError,
+    refetch: participantsRefetch,
+  } = useParticipants(surveyId);
+
+  const participants = useMemo(() => {
+    return participantData?.participants || [];
+  }, [participantData]);
+
+  const [currentParticipantIndex, setCurrentParticipantIndex] = useState(0);
+  const [inputIndex, setInputIndex] = useState(currentParticipantIndex.toString());
+
+  useEffect(() => {
+    if (participants.length > 0) {
+      if (participantId) {
+        const index = participants.findIndex((p) => p.participantId === participantId);
+        if (index !== -1) {
+          setCurrentParticipantIndex(index);
+          setInputIndex((index + 1).toString());
+        } else {
+          setCurrentParticipantIndex(0);
+          setInputIndex('1');
+        }
+      } else {
+        setCurrentParticipantIndex(0);
+        setInputIndex('1');
+      }
+    }
+  }, [participants]);
+
+  const currentParticipantId =
+    participants.length > 0 ? participants[currentParticipantIndex].participantId : undefined;
+
+  const { data, isLoading, isError, refetch } = useSurveyResult(
+    surveyId,
+    { questionFilters: [] },
+    currentParticipantId,
+    {
+      enabled: !!currentParticipantId, // currentParticipantId가 있을 때만 쿼리 실행
+    }
+  );
+
+  if (participantsIsLoading)
+    return (
+      <div className={styles.loading}>
+        <Loading message="참가자 목록을 불러오는 중..." />
+      </div>
+    );
+
+  if (participantsIsError)
+    return (
+      <div className={styles.error}>
+        <Error
+          message="참가자 목록을 불러오지 못했습니다."
+          buttons={[{ text: '재시도', fn: participantsRefetch }]}
+          margin="18px"
+        />
+      </div>
+    );
+
+  if (participants.length === 0) {
+    return <div>참가자가 없습니다.</div>;
+  }
+
+  const handlePrevParticipant = () => {
+    deleteURLSearchParam('participantId');
+    if (currentParticipantIndex > 0) {
+      setCurrentParticipantIndex(currentParticipantIndex - 1);
+      setInputIndex(currentParticipantIndex.toString());
+    }
+  };
+
+  const handleNextParticipant = () => {
+    deleteURLSearchParam('participantId');
+    if (currentParticipantIndex < participants.length - 1) {
+      setCurrentParticipantIndex(currentParticipantIndex + 1);
+      setInputIndex((currentParticipantIndex + 2).toString());
+    }
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value.trim();
+    setInputIndex(value);
+
+    if (value === '' || Number.isNaN(Number(value))) return;
+    const index = parseInt(value, 10) - 1;
+    if (index >= 0 && index < participants.length) {
+      setCurrentParticipantIndex(index);
+    }
+  };
+
+  const currentParticipant = participants[currentParticipantIndex];
+
   return (
     <div className={styles.container}>
-      <h3>개별 응답</h3>
+      <div>
+        <div className={styles.navigation}>
+          <button
+            type="button"
+            onClick={handlePrevParticipant}
+            disabled={currentParticipantIndex === 0}
+            className={styles.navButton}
+            aria-label="이전 참가자">
+            <FaArrowLeft />
+          </button>
+          <input
+            type="text"
+            value={inputIndex}
+            onChange={handleInputChange}
+            className={styles.indexInput}
+            aria-label="참가자 인덱스 입력"
+          />
+          <span>/ {participants.length}</span>
+          <button
+            type="button"
+            onClick={handleNextParticipant}
+            disabled={currentParticipantIndex === participants.length - 1}
+            className={styles.navButton}
+            aria-label="다음 참가자">
+            <FaArrowRight />
+          </button>
+        </div>
+        <div className={styles.participationDate}>
+          <FaCalendarAlt className={styles.calendarIcon} />
+          <span>참가 일시: {moment(currentParticipant.participatedAt).format('YYYY-MM-DD HH:mm:ss')}</span>
+        </div>
+      </div>
+
+      {(() => {
+        if (isLoading) {
+          return (
+            <div className={styles.loading}>
+              <Loading message="데이터를 불러오는 중..." />
+            </div>
+          );
+        }
+        if (isError) {
+          return (
+            <div className={styles.error}>
+              <Error
+                message="데이터를 불러오지 못했습니다."
+                buttons={[{ text: '재시도', fn: refetch }]}
+                margin="18px"
+              />
+            </div>
+          );
+        }
+        return data?.sectionResults.map((sectionResult: SectionResult) => (
+          <SectionResultViewer key={sectionResult.sectionId} sectionResult={sectionResult} />
+        ));
+      })()}
     </div>
   );
 }
-
-export default Tab2;

--- a/src/app/management/[id]/tab2.tsx
+++ b/src/app/management/[id]/tab2.tsx
@@ -74,7 +74,11 @@ export default function Tab2({ surveyId, participantId }: { surveyId: string; pa
     );
 
   if (participants.length === 0) {
-    return <div>참가자가 없습니다.</div>;
+    return (
+      <div className={styles.container}>
+        <h4>참가자가 없습니다.</h4>
+      </div>
+    );
   }
 
   const handlePrevParticipant = () => {

--- a/src/app/management/[id]/tab2.tsx
+++ b/src/app/management/[id]/tab2.tsx
@@ -41,7 +41,7 @@ export default function Tab2({ surveyId, participantId }: { surveyId: string; pa
         setInputIndex('1');
       }
     }
-  }, [participants]);
+  }, [participantId, participants]);
 
   const currentParticipantId =
     participants.length > 0 ? participants[currentParticipantIndex].participantId : undefined;

--- a/src/app/management/[id]/tab3.module.css
+++ b/src/app/management/[id]/tab3.module.css
@@ -2,7 +2,7 @@
   box-sizing: border-box;
   border-radius: 8px;
   width: 100%;
-  max-width: 600px;
+  max-width: var(--container-width);
   margin: 0 auto;
   padding: 12px;
 }
@@ -12,4 +12,98 @@
 .container input,
 .container textarea {
   box-sizing: border-box;
+}
+
+.buttonGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: center;
+}
+
+.button {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 20px;
+  font-size: 14px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.3s, transform 0.2s;
+  color: white;
+}
+
+.editButton {
+  background-color: #0070f3;
+}
+
+.editButton:disabled {
+  background-color: #b0c4de;
+  cursor: not-allowed;
+}
+
+.editButton:hover:not(:disabled) {
+  background-color: #005bb5;
+  transform: translateY(-2px);
+}
+
+.finishButton {
+  background-color: #e53e3e;
+}
+
+.finishButton:disabled {
+  background-color: #f7c1c1;
+  cursor: not-allowed;
+}
+
+.finishButton:hover:not(:disabled) {
+  background-color: #c53030;
+  transform: translateY(-2px);
+}
+
+.shareButton {
+  background-color: #38a169;
+}
+
+.shareButton:hover {
+  background-color: #2f855a;
+  transform: translateY(-2px);
+}
+
+.icon {
+  font-size: 16px;
+}
+
+.modalActions {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  margin-top: 16px;
+}
+
+.confirmButton {
+  background: #0070f3;
+  color: white;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.confirmButton:hover {
+  background: #005bb5;
+}
+
+.cancelButton {
+  background: #ccc;
+  color: black;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.cancelButton:hover {
+  background: #aaa;
 }

--- a/src/app/management/[id]/tab3.module.css
+++ b/src/app/management/[id]/tab3.module.css
@@ -14,6 +14,11 @@
   box-sizing: border-box;
 }
 
+.loading {
+  display: flex;
+  justify-content: center;
+}
+
 .buttonGroup {
   display: flex;
   flex-direction: column;

--- a/src/app/management/[id]/tab3.tsx
+++ b/src/app/management/[id]/tab3.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { FaEdit, FaRegCopy, FaRegStopCircle } from 'react-icons/fa'; // 아이콘 추가
+import React, { useState } from 'react';
+import { FaEdit, FaRegCopy, FaRegStopCircle } from 'react-icons/fa';
 import useModal from '@/hooks/useModal';
 import Modal from '@/components/ui/modal/Modal';
 import { fetchSurveyEdit, fetchSurveyFinish } from '@/services/management/fetch';
@@ -8,12 +8,14 @@ import styles from './tab3.module.css';
 
 interface Tab3Props {
   surveyId: string;
-  isFinished: boolean;
+  initialIsFinished: boolean;
 }
 
-function Tab3({ surveyId, isFinished }: Tab3Props) {
+function Tab3({ surveyId, initialIsFinished }: Tab3Props) {
   const { isOpen: isEditModalOpen, openModal: openEditModal, closeModal: closeEditModal } = useModal();
   const { isOpen: isFinishModalOpen, openModal: openFinishModal, closeModal: closeFinishModal } = useModal();
+
+  const [isFinished, setIsFinished] = useState(initialIsFinished);
 
   const handleEditSurvey = async () => {
     closeEditModal();
@@ -21,7 +23,7 @@ function Tab3({ surveyId, isFinished }: Tab3Props) {
       await fetchSurveyEdit({ surveyId });
       window.location.href = `/workbench/${surveyId}`;
     } catch (error) {
-      showToast('error', '설문을 종료하지 못했습니다.');
+      showToast('error', '설문을 수정 상태로 변경하지 못했습니다.');
     }
   };
 
@@ -30,8 +32,9 @@ function Tab3({ surveyId, isFinished }: Tab3Props) {
     try {
       await fetchSurveyFinish({ surveyId });
       showToast('success', '설문을 성공적으로 종료했습니다.');
+      setIsFinished(true);
     } catch (error) {
-      showToast('error', '설문을 수정 상태로 변경하지 못했습니다.');
+      showToast('error', '설문을 종료하지 못했습니다.');
     }
   };
 

--- a/src/app/management/[id]/tab3.tsx
+++ b/src/app/management/[id]/tab3.tsx
@@ -1,11 +1,96 @@
 import React from 'react';
-import 'moment/locale/ko';
+import { FaEdit, FaRegCopy, FaRegStopCircle } from 'react-icons/fa'; // 아이콘 추가
+import useModal from '@/hooks/useModal';
+import Modal from '@/components/ui/modal/Modal';
+import { fetchSurveyEdit, fetchSurveyFinish } from '@/services/management/fetch';
+import { showToast } from '@/utils/toast';
 import styles from './tab3.module.css';
 
-function Tab3() {
+interface Tab3Props {
+  surveyId: string;
+  isFinished: boolean;
+}
+
+function Tab3({ surveyId, isFinished }: Tab3Props) {
+  const { isOpen: isEditModalOpen, openModal: openEditModal, closeModal: closeEditModal } = useModal();
+  const { isOpen: isFinishModalOpen, openModal: openFinishModal, closeModal: closeFinishModal } = useModal();
+
+  const handleEditSurvey = async () => {
+    closeEditModal();
+    try {
+      await fetchSurveyEdit({ surveyId });
+      window.location.href = `/workbench/${surveyId}`;
+    } catch (error) {
+      showToast('error', '설문을 종료하지 못했습니다.');
+    }
+  };
+
+  const handleFinishSurvey = async () => {
+    closeFinishModal();
+    try {
+      await fetchSurveyFinish({ surveyId });
+      showToast('success', '설문을 성공적으로 종료했습니다.');
+    } catch (error) {
+      showToast('error', '설문을 수정 상태로 변경하지 못했습니다.');
+    }
+  };
+
+  const handleCopyLink = () => {
+    const surveyLink = `${window.location.origin}/s/${surveyId}`;
+    navigator.clipboard.writeText(surveyLink);
+    showToast('success', '설문 참여 링크가 클립보드에 복사되었습니다.');
+  };
+
   return (
     <div className={styles.container}>
-      <h3>설정</h3>
+      <div className={styles.buttonGroup}>
+        <button
+          type="button"
+          onClick={openEditModal}
+          className={`${styles.button} ${styles.editButton}`}
+          disabled={isFinished}
+          aria-disabled={isFinished}>
+          <FaEdit className={styles.icon} />
+          설문 수정
+        </button>
+        <button
+          type="button"
+          onClick={openFinishModal}
+          className={`${styles.button} ${styles.finishButton}`}
+          disabled={isFinished}
+          aria-disabled={isFinished}>
+          <FaRegStopCircle className={styles.icon} />
+          설문 종료
+        </button>
+        <button type="button" onClick={handleCopyLink} className={`${styles.button} ${styles.shareButton}`}>
+          <FaRegCopy className={styles.icon} />
+          설문 공유
+        </button>
+      </div>
+
+      <Modal isOpen={isEditModalOpen} onClose={closeEditModal} title="설문 수정 확인">
+        <p>설문을 수정하는 동안에는 응답을 받을 수 없습니다. 설문을 수정하시겠습니까?</p>
+        <div className={styles.modalActions}>
+          <button type="button" onClick={handleEditSurvey} className={styles.confirmButton}>
+            확인
+          </button>
+          <button type="button" onClick={closeEditModal} className={styles.cancelButton}>
+            취소
+          </button>
+        </div>
+      </Modal>
+
+      <Modal isOpen={isFinishModalOpen} onClose={closeFinishModal} title="설문 종료 확인">
+        <p>설문을 종료하면 더 이상 응답을 받을 수 없습니다. 설문을 종료하시겠습니까?</p>
+        <div className={styles.modalActions}>
+          <button type="button" onClick={handleFinishSurvey} className={styles.confirmButton}>
+            확인
+          </button>
+          <button type="button" onClick={closeFinishModal} className={styles.cancelButton}>
+            취소
+          </button>
+        </div>
+      </Modal>
     </div>
   );
 }

--- a/src/app/management/[id]/tab3.tsx
+++ b/src/app/management/[id]/tab3.tsx
@@ -4,6 +4,8 @@ import useModal from '@/hooks/useModal';
 import Modal from '@/components/ui/modal/Modal';
 import { fetchSurveyEdit, fetchSurveyFinish } from '@/services/management/fetch';
 import { showToast } from '@/utils/toast';
+import Button from '@/components/ui/button/Button';
+import { writeClipboard } from '@/utils/misc';
 import styles from './tab3.module.css';
 
 interface Tab3Props {
@@ -40,7 +42,7 @@ function Tab3({ surveyId, initialIsFinished }: Tab3Props) {
 
   const handleCopyLink = () => {
     const surveyLink = `${window.location.origin}/s/${surveyId}`;
-    navigator.clipboard.writeText(surveyLink);
+    writeClipboard(surveyLink);
     showToast('success', '설문 참여 링크가 클립보드에 복사되었습니다.');
   };
 
@@ -74,24 +76,24 @@ function Tab3({ surveyId, initialIsFinished }: Tab3Props) {
       <Modal isOpen={isEditModalOpen} onClose={closeEditModal} title="설문 수정 확인">
         <p>설문을 수정하는 동안에는 응답을 받을 수 없습니다. 설문을 수정하시겠습니까?</p>
         <div className={styles.modalActions}>
-          <button type="button" onClick={handleEditSurvey} className={styles.confirmButton}>
-            확인
-          </button>
-          <button type="button" onClick={closeEditModal} className={styles.cancelButton}>
+          <Button variant="primary" onClick={handleEditSurvey}>
+            수정하기
+          </Button>
+          <Button variant="secondary" onClick={closeEditModal}>
             취소
-          </button>
+          </Button>
         </div>
       </Modal>
 
       <Modal isOpen={isFinishModalOpen} onClose={closeFinishModal} title="설문 종료 확인">
         <p>설문을 종료하면 더 이상 응답을 받을 수 없습니다. 설문을 종료하시겠습니까?</p>
         <div className={styles.modalActions}>
-          <button type="button" onClick={handleFinishSurvey} className={styles.confirmButton}>
-            확인
-          </button>
-          <button type="button" onClick={closeFinishModal} className={styles.cancelButton}>
+          <Button variant="primary" onClick={handleFinishSurvey}>
+            종료하기
+          </Button>
+          <Button variant="secondary" onClick={closeEditModal}>
             취소
-          </button>
+          </Button>
         </div>
       </Modal>
     </div>

--- a/src/app/management/[id]/tab3.tsx
+++ b/src/app/management/[id]/tab3.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { FaEdit, FaRegCopy, FaRegStopCircle } from 'react-icons/fa';
 import useModal from '@/hooks/useModal';
 import Modal from '@/components/ui/modal/Modal';
@@ -6,18 +6,22 @@ import { fetchSurveyEdit, fetchSurveyFinish } from '@/services/management/fetch'
 import { showToast } from '@/utils/toast';
 import Button from '@/components/ui/button/Button';
 import { writeClipboard } from '@/utils/misc';
+import Loading from '@/components/ui/loading/Loading';
 import styles from './tab3.module.css';
 
 interface Tab3Props {
   surveyId: string;
-  initialIsFinished: boolean;
+  initialIsFinished: undefined | boolean;
 }
 
 function Tab3({ surveyId, initialIsFinished }: Tab3Props) {
   const { isOpen: isEditModalOpen, openModal: openEditModal, closeModal: closeEditModal } = useModal();
   const { isOpen: isFinishModalOpen, openModal: openFinishModal, closeModal: closeFinishModal } = useModal();
+  const [isFinished, setIsFinished] = useState<boolean>();
 
-  const [isFinished, setIsFinished] = useState(initialIsFinished);
+  useEffect(() => {
+    setIsFinished(initialIsFinished);
+  }, [initialIsFinished]);
 
   const handleEditSurvey = async () => {
     closeEditModal();
@@ -45,6 +49,13 @@ function Tab3({ surveyId, initialIsFinished }: Tab3Props) {
     writeClipboard(surveyLink);
     showToast('success', '설문 참여 링크가 클립보드에 복사되었습니다.');
   };
+
+  if (initialIsFinished === undefined)
+    return (
+      <div className={styles.loading}>
+        <Loading message="설문 정보를 불러오는 중..." />
+      </div>
+    );
 
   return (
     <div className={styles.container}>

--- a/src/components/main/banner/Banner.tsx
+++ b/src/components/main/banner/Banner.tsx
@@ -31,11 +31,11 @@ export default function Banner() {
     // }
   };
 
-  const tryPushToMyPage = async () => {
+  const tryPushToMyPage = () => {
     try {
       if (user != null) nextRouter.push(`/mypage`);
       else {
-        alert('로그인이 필요합니다!');
+        showToast('info', '로그인이 필요합니다!');
         nextRouter.push(`/login`);
       }
     } catch (err) {

--- a/src/components/management/participant/ParticipantList.module.css
+++ b/src/components/management/participant/ParticipantList.module.css
@@ -56,10 +56,18 @@
   color: #0070f3;
   text-decoration: none;
   font-weight: 600;
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: pointer;
 }
 
 .viewButton:hover {
   color: #0056b3;
+}
+
+.viewButton:focus {
+  outline: none;
 }
 
 .viewButton svg {

--- a/src/components/management/participant/ParticipantList.tsx
+++ b/src/components/management/participant/ParticipantList.tsx
@@ -1,15 +1,22 @@
 import React from 'react';
 import moment from 'moment';
-import Link from 'next/link';
 import { ParticipantInfo } from '@/services/participant/types';
 import { FaEye } from 'react-icons/fa';
+import { replaceURLSearchParams } from '@/utils/url-search-params';
 import styles from './ParticipantList.module.css';
 
 interface ParticipantListProps {
   participants: ParticipantInfo[];
+  setTab: React.Dispatch<React.SetStateAction<number>>;
 }
 
-export default function ParticipantList({ participants }: ParticipantListProps) {
+export default function ParticipantList({ participants, setTab }: ParticipantListProps) {
+  const handleLinkClick = (participantId: string) => {
+    replaceURLSearchParams('tab', 2);
+    replaceURLSearchParams('participantId', participantId);
+    setTab(2);
+  };
+
   return (
     <div className={styles.participantList}>
       <h2 className={styles.title}>참가자 목록</h2>
@@ -25,10 +32,13 @@ export default function ParticipantList({ participants }: ParticipantListProps) 
             <tr key={participant.participantId}>
               <td>{moment(participant.participatedAt).format('YYYY-MM-DD HH:mm:ss')}</td>
               <td className={styles.viewButtonCell}>
-                <Link href={`/participant/${participant.participantId}`} className={styles.viewButton}>
+                <button
+                  type="button"
+                  onClick={() => handleLinkClick(participant.participantId)}
+                  className={styles.viewButton}>
                   <FaEye />
                   <span>응답 보기</span>
-                </Link>
+                </button>
               </td>
             </tr>
           ))}

--- a/src/components/management/participant/WinnerList.module.css
+++ b/src/components/management/participant/WinnerList.module.css
@@ -35,7 +35,6 @@
 
 .winnerTable td {
   color: #666;
-  position: relative;
 }
 
 .winnerTable tr:nth-child(even) {
@@ -47,20 +46,31 @@
 }
 
 .phoneNumberCell {
-  display: flex;
+  text-align: center;
+  padding: 0;
+}
+
+.phoneNumberInfo {
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 8px;
+  border: none;
+  background: none;
+  padding: 0;
+}
+
+.phoneNumber {
+  width: 120px;
 }
 
 .eyeButton {
+  display: flex;
   background: none;
   border: none;
   cursor: pointer;
   color: #0070f3;
   padding: 0;
-  display: flex;
-  align-items: center;
 }
 
 .eyeButton:hover {

--- a/src/components/management/participant/WinnerList.module.css
+++ b/src/components/management/participant/WinnerList.module.css
@@ -35,6 +35,7 @@
 
 .winnerTable td {
   color: #666;
+  position: relative;
 }
 
 .winnerTable tr:nth-child(even) {
@@ -43,4 +44,25 @@
 
 .winnerTable tr:hover {
   background-color: #f1f7ff;
+}
+
+.phoneNumberCell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
+.eyeButton {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #0070f3;
+  padding: 0;
+  display: flex;
+  align-items: center;
+}
+
+.eyeButton:hover {
+  color: #005bb5;
 }

--- a/src/components/management/participant/WinnerList.tsx
+++ b/src/components/management/participant/WinnerList.tsx
@@ -1,3 +1,5 @@
+import React, { useState } from 'react';
+import { FaEye, FaEyeSlash } from 'react-icons/fa';
 import moment from 'moment';
 import { ParticipantInfo } from '@/services/participant/types';
 import styles from './WinnerList.module.css';
@@ -7,6 +9,20 @@ interface WinnerListProps {
 }
 
 export default function WinnerList({ winners }: WinnerListProps) {
+  const [visiblePhoneNumbers, setVisiblePhoneNumbers] = useState<{ [key: string]: boolean }>({});
+
+  const maskPhoneNumber = (phoneNumber: string | undefined) => {
+    if (!phoneNumber) return '***-****-****';
+    return phoneNumber.replace(/(\d{3})[-]?(\d{4})[-]?(\d{4})/, '$1-****-$3');
+  };
+
+  const togglePhoneNumberVisibility = (participantId: string) => {
+    setVisiblePhoneNumbers((prevState) => ({
+      ...prevState,
+      [participantId]: !prevState[participantId],
+    }));
+  };
+
   return (
     <div className={styles.winnerList}>
       <h2 className={styles.title}>당첨자 목록</h2>
@@ -19,13 +35,28 @@ export default function WinnerList({ winners }: WinnerListProps) {
           </tr>
         </thead>
         <tbody>
-          {winners.map((winner) => (
-            <tr key={winner.participantId}>
-              <td>{moment(winner.participatedAt).format('YYYY-MM-DD HH:mm:ss')}</td>
-              <td>{winner.drawInfo?.reward}</td>
-              <td>{winner.drawInfo?.phoneNumber}</td>
-            </tr>
-          ))}
+          {winners.map((winner) => {
+            const isPhoneNumberVisible = visiblePhoneNumbers[winner.participantId] || false;
+
+            const phoneNumber = winner.drawInfo?.phoneNumber || '';
+
+            return (
+              <tr key={winner.participantId}>
+                <td>{moment(winner.participatedAt).format('YYYY-MM-DD HH:mm:ss')}</td>
+                <td>{winner.drawInfo?.reward || 'N/A'}</td>
+                <td className={styles.phoneNumberCell}>
+                  {isPhoneNumberVisible ? phoneNumber : maskPhoneNumber(phoneNumber)}
+                  <button
+                    type="button"
+                    className={styles.eyeButton}
+                    onClick={() => togglePhoneNumberVisibility(winner.participantId)}
+                    aria-label="전화번호 보기">
+                    {isPhoneNumberVisible ? <FaEyeSlash /> : <FaEye />}
+                  </button>
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </div>

--- a/src/components/management/participant/WinnerList.tsx
+++ b/src/components/management/participant/WinnerList.tsx
@@ -45,14 +45,18 @@ export default function WinnerList({ winners }: WinnerListProps) {
                 <td>{moment(winner.participatedAt).format('YYYY-MM-DD HH:mm:ss')}</td>
                 <td>{winner.drawInfo?.reward || 'N/A'}</td>
                 <td className={styles.phoneNumberCell}>
-                  {isPhoneNumberVisible ? phoneNumber : maskPhoneNumber(phoneNumber)}
-                  <button
-                    type="button"
-                    className={styles.eyeButton}
-                    onClick={() => togglePhoneNumberVisibility(winner.participantId)}
-                    aria-label="전화번호 보기">
-                    {isPhoneNumberVisible ? <FaEyeSlash /> : <FaEye />}
-                  </button>
+                  <div className={styles.phoneNumberInfo}>
+                    <span className={styles.phoneNumber}>
+                      {isPhoneNumberVisible ? phoneNumber : maskPhoneNumber(phoneNumber)}
+                    </span>
+                    <button
+                      type="button"
+                      className={styles.eyeButton}
+                      onClick={() => togglePhoneNumberVisibility(winner.participantId)}
+                      aria-label="전화번호 보기">
+                      {isPhoneNumberVisible ? <FaEyeSlash /> : <FaEye />}
+                    </button>
+                  </div>
                 </td>
               </tr>
             );

--- a/src/components/management/result/FilterManager.module.css
+++ b/src/components/management/result/FilterManager.module.css
@@ -20,9 +20,17 @@
   font-weight: 500;
 }
 
-.addButton:hover,
-.searchButton:hover {
+.addButton:hover {
   background-color: rgb(220, 183, 28); /* 진한 색상 */
+}
+
+.searchButton {
+  background-color: #0070f3;
+  color: white;
+}
+
+.searchButton:hover {
+  background-color: #0056b3;
 }
 
 .buttonIcon {

--- a/src/components/management/result/FilterManager.tsx
+++ b/src/components/management/result/FilterManager.tsx
@@ -74,7 +74,7 @@ export default function FilterManager({ onSearch, resultInfo }: FilterManagerPro
           <FaPlus className={styles.buttonIcon} /> 필터 추가
         </button>
         <button type="button" onClick={handleSearch} className={styles.searchButton}>
-          <FaSearch className={styles.buttonIcon} /> 검색
+          <FaSearch className={styles.buttonIcon} /> 필터 적용
         </button>
       </div>
       {tempFilters.map((filter, index) => (

--- a/src/components/mypage/Header.module.css
+++ b/src/components/mypage/Header.module.css
@@ -17,6 +17,7 @@
   align-items: flex-start;
   justify-content: center;
   padding-left: 12px;
+  white-space: nowrap;
 }
 
 .userdata > div {

--- a/src/components/ui/modal/Modal.module.css
+++ b/src/components/ui/modal/Modal.module.css
@@ -30,7 +30,11 @@
 
   padding: 12px 20px;
   border-bottom: 1px solid var(--gray-ml);
-  height: 42px;
+}
+
+.modalTop h2 {
+  padding: 0;
+  margin: 0;
 }
 
 .closeButton {

--- a/src/services/ky-wrapper.ts
+++ b/src/services/ky-wrapper.ts
@@ -70,6 +70,19 @@ class KyWrapper {
       });
     }
   }
+
+  async patch<T>(URL: string, options?: Options) {
+    try {
+      return await this.kyInstance.patch(URL, options).json<T>();
+    } catch (e) {
+      if (e instanceof HTTPError) {
+        throw e;
+      }
+      throw new Error('서버와의 통신에 실패했습니다.', {
+        cause: { code: undefined, errors: undefined, message: '서버와의 통신에 실패했습니다.' },
+      });
+    }
+  }
 }
 
 export interface ErrorCause {

--- a/src/services/management/fetch.ts
+++ b/src/services/management/fetch.ts
@@ -1,0 +1,16 @@
+import { kyWrapper } from '../ky-wrapper';
+import { makeUrl } from '../utils';
+
+interface EmptyResponse {}
+
+const fetchSurveyEdit = async ({ surveyId }: { surveyId: string }) => {
+  const URL = makeUrl(['surveys', 'workbench', 'edit', surveyId]);
+  return kyWrapper.patch<EmptyResponse>(URL);
+};
+
+const fetchSurveyFinish = async ({ surveyId }: { surveyId: string }) => {
+  const URL = makeUrl(['surveys', 'workbench', 'finish', surveyId]);
+  return kyWrapper.patch<EmptyResponse>(URL);
+};
+
+export { fetchSurveyEdit, fetchSurveyFinish };

--- a/src/services/result/fetch.ts
+++ b/src/services/result/fetch.ts
@@ -1,9 +1,9 @@
 import { kyWrapper } from '../ky-wrapper';
-import { makeUrl } from '../utils';
+import { makeUrlWithUndefined } from '../utils';
 import type { SurveyResult, SurveysResultParams } from './types';
 
-const getResults = async ({ surveyId, resultFilter }: SurveysResultParams) => {
-  const URL = makeUrl(['surveys', 'result', surveyId]);
+const getResults = async ({ surveyId, resultFilter, participantId }: SurveysResultParams) => {
+  const URL = makeUrlWithUndefined(['surveys', 'result', surveyId], { participantId });
   return kyWrapper.post<SurveyResult>(URL, { json: resultFilter });
 };
 

--- a/src/services/result/index.ts
+++ b/src/services/result/index.ts
@@ -3,14 +3,25 @@ import { getResults } from '@/services/result/fetch';
 import type { ResultFilter } from './types';
 
 const queryKeys = {
-  getResults: (surveyId: string, resultFilter: ResultFilter) => ['getResults', surveyId, resultFilter],
+  getResults: (surveyId: string, resultFilter: ResultFilter, participantId: string | undefined) => [
+    'getResults',
+    surveyId,
+    resultFilter,
+    participantId,
+  ],
 };
 
-const useSurveyResult = (surveyId: string, resultFilter: ResultFilter) => {
+const useSurveyResult = (
+  surveyId: string,
+  resultFilter: ResultFilter,
+  participantId: string | undefined,
+  options?: { enabled?: boolean }
+) => {
   return useQuery({
-    queryKey: queryKeys.getResults(surveyId, resultFilter),
-    queryFn: () => getResults({ surveyId, resultFilter }),
+    queryKey: queryKeys.getResults(surveyId, resultFilter, participantId),
+    queryFn: () => getResults({ surveyId, resultFilter, participantId }),
     placeholderData: keepPreviousData,
+    enabled: options?.enabled,
   });
 };
 

--- a/src/services/result/types.ts
+++ b/src/services/result/types.ts
@@ -26,6 +26,7 @@ interface Response {
 interface SurveysResultParams {
   surveyId: string;
   resultFilter: ResultFilter;
+  participantId: string | undefined;
 }
 
 interface ResultFilter {

--- a/src/services/utils.ts
+++ b/src/services/utils.ts
@@ -12,4 +12,21 @@ const makeUrl = (api: string[], params?: { [key: string]: string | number | bool
   return `${URL}?${PARAMS.join('&')}`;
 };
 
-export { makeUrl };
+// queryString의 value가 undefined면 무시하면서 URL을 만드는 util 함수
+const makeUrlWithUndefined = (api: string[], params?: { [key: string]: string | number | boolean | undefined }) => {
+  const URL = [VERSION, ...api].join('/');
+  const PARAMS = [] as string[];
+
+  if (params) {
+    Object.keys(params).forEach((key) => {
+      if (params[key] !== undefined) {
+        PARAMS.push(`${key}=${params[key]}`);
+      }
+    });
+  }
+
+  if (PARAMS.length === 0) return URL;
+  return `${URL}?${PARAMS.join('&')}`;
+};
+
+export { makeUrl, makeUrlWithUndefined };

--- a/src/utils/url-search-params.ts
+++ b/src/utils/url-search-params.ts
@@ -22,4 +22,11 @@ function replaceURLSearchParams(key: string, val: string | number) {
   window.history.replaceState({ path: newurl }, '', newurl);
 }
 
-export { pushURLSearchParams, replaceURLSearchParams };
+function deleteURLSearchParam(key: string) {
+  const params = new URLSearchParams(window.location.search);
+  params.delete(key);
+  const newUrl = `${window.location.pathname}?${params.toString()}`;
+  window.history.replaceState({}, '', newUrl);
+}
+
+export { pushURLSearchParams, replaceURLSearchParams, deleteURLSearchParam };


### PR DESCRIPTION
## 📢 설명

- 각 참여자의 개별 응답을 확인할 수 있는 개별 응답 탭 구현
    
    참가자 관리 페이지의 응답 보기와 연결 완료
    
    ![image](https://github.com/user-attachments/assets/75205739-bf92-481e-bc70-79c4eb229888)
    
- 설문을 수정 상태로 바꾸거나, 종료하거나, 공유할 수 있는 기능이 담긴 설정 탭 구현
    
    ![image](https://github.com/user-attachments/assets/5c3ada02-9ea8-4cab-9343-bf545afb87f2)
    
- 전화번호 마스킹 기능 구현
    
    ![image](https://github.com/user-attachments/assets/401c471d-a82e-4e0e-9dd4-0c71d09e48f6)
    
    ![image](https://github.com/user-attachments/assets/0a7a4f14-ebe9-4439-95bb-5b1b603a5d28)
    
- 통계 보기의 검색 버튼의 색을 바꾸고, 텍스트를 "필터 적용"으로 수정
    
    ![image](https://github.com/user-attachments/assets/8c9ba1cf-eb4d-44e9-b335-520cba28bd8f)
    
- 마이페이지에서 진행 중, 마감 상태의 설문 클릭시 설문 관리 페이지로 가도록 수정(원래 마감 상태는 제작으로 갔었음)
- 설문이 진행중이 아니거나 마감 상태가 아닌 경우 관리 페이지에서 내쫓는 기능 구현

## ✅ 체크 리스트

- [x]  참가자 관리 페이지에서 응답 보기 클릭 시 해당 참가자의 개별 응답을 볼 수 있는지 확인
    
    ![image](https://github.com/user-attachments/assets/b7d56e73-e5e1-4ff2-9bf6-be5eb2b04156)
    
- [x]  개별 응답 페이지에서 이전, 다음 버튼 클릭 or 직접 번호 입력 시 해당 index의 참가자가 잘 나오는지 확인
    
    ![image](https://github.com/user-attachments/assets/c48f2f74-a362-45d9-bed0-8d5d388825e6)
    
- [x]  설정 탭의 설문 수정 버튼 클릭 + 모달에서 확인 클릭 시 제작 페이지로 이동되고, 설문 수정이 잘 되는지 확인
- [x]  설정 탭의 설문 종료 버튼 클릭 + 모달에서 확인 클릭 시 설문이 종료되는지, 바로 설문 수정 버튼과 종료 버튼이 비활성화 되는지 확인
    
    ![image](https://github.com/user-attachments/assets/5d670be9-69fc-4e78-9348-ef78cd69ef58)
    
- [x]  설문 공유 버튼 클릭 시 클립보드에 설문 참여 페이지 링크가 클립보드에 잘 복사되는지 확인
- [x] 제작 or 수정 중인 설문에 들어가서 url의 workbench를 management로 수정해서 관리페이지 진입 시 alert 후 마이 페이지로 이동되는지 확인
- [x]  그 외 기타 기능 확인 및 코드 리뷰