### PR TITLE
[SBL-132] 메인 페이지, 설문 상세 정보 페이지 컴포넌트 및 css 개선

### DIFF
--- a/src/app/s/[surveyId]/page.tsx
+++ b/src/app/s/[surveyId]/page.tsx
@@ -1,16 +1,14 @@
 'use client';
 
 import DetailsViewer from '@/components/survey-details';
-import { getSurveyState } from '@/components/survey-p/funcs/storage';
 import Loading from '@/components/ui/loading/Loading';
 import { useSurveysDetails } from '@/services/surveys';
 
 export default function Page({ params }: { params: { surveyId: string } }) {
   const { surveyId } = params;
   const { data, isLoading } = useSurveysDetails(surveyId);
-  const surveyState = getSurveyState(surveyId);
 
   if (isLoading || !data) return <Loading message="설문조사 정보를 불러오는 중..." />;
 
-  return <DetailsViewer data={data} surveyId={surveyId} state={surveyState} />;
+  return <DetailsViewer data={data} surveyId={surveyId} />;
 }

--- a/src/components/main/survey-finder/item/Item.module.css
+++ b/src/components/main/survey-finder/item/Item.module.css
@@ -56,7 +56,12 @@
 }
 
 .description {
-  display: none;
+  font-size: 14px;
+  display: block;
+  padding: 4px 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .time {
@@ -97,17 +102,6 @@
 
 .feasibility > div > svg {
   color: var(--gray-d);
-}
-
-@media screen and (min-width: 425px) {
-  .description {
-    font-size: 14px;
-    display: block;
-    padding: 4px 0;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
 }
 
 @media screen and (max-width: 1079px) {

--- a/src/components/main/survey-finder/item/Item.module.css
+++ b/src/components/main/survey-finder/item/Item.module.css
@@ -96,7 +96,7 @@
 }
 
 .feasibility > div > svg {
-  color: #000;
+  color: var(--gray-d);
 }
 
 @media screen and (min-width: 425px) {
@@ -104,13 +104,28 @@
     font-size: 14px;
     display: block;
     padding: 4px 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
+@media screen and (max-width: 1079px) {
+  .info {
+    flex-grow: 1;
+    width: auto;
+    overflow: hidden;
+  }
+
+  .item {
+    grid-template-columns: 100px 1fr;
   }
 }
 
 @media screen and (min-width: 1080px) {
   .item {
     width: 220px;
-    height: 360px;
+    height: 320px;
     display: flex;
     flex-direction: column;
     row-gap: 1rem;

--- a/src/components/main/survey-finder/item/Item.module.css
+++ b/src/components/main/survey-finder/item/Item.module.css
@@ -50,6 +50,9 @@
 
 .title {
   font-size: 16px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .description {
@@ -74,6 +77,7 @@
   align-items: center;
   justify-content: flex-end;
   gap: 1rem;
+  height: 17px;
 
   font-size: 14px;
 }
@@ -133,10 +137,10 @@
 
   .description {
     padding-top: 8px;
-  }
-
-  .rewards {
-    padding-top: 8px;
+    max-height: 60px;
+    overflow: hidden;
+    white-space: wrap;
+    text-overflow: ellipsis;
   }
 }
 

--- a/src/components/main/survey-finder/item/Item.tsx
+++ b/src/components/main/survey-finder/item/Item.tsx
@@ -23,7 +23,7 @@ export default function ListItem({ survey }: { survey: Survey }) {
       />
       <div className={styles.info}>
         <div>
-          <div className={styles.title}>{title.length < 28 ? title : `${title.substring(0, 25).trim()}...`}</div>
+          <div className={styles.title}>{title}</div>
           <div className={styles.time}>{finishedAt ? dateReader(finishedAt) : '응답 받는 중'}</div>
           <div className={styles.description}>{description}</div>
           <div className={styles.rewards}>

--- a/src/components/main/survey-finder/item/Item.tsx
+++ b/src/components/main/survey-finder/item/Item.tsx
@@ -15,12 +15,16 @@ export default function ListItem({ survey }: { survey: Survey }) {
     <Link className={styles.item} href={`/s/${surveyId}`}>
       <div
         className={styles.thumbnail}
-        style={{ backgroundColor: 'var(--gray-ml)', backgroundSize: 'cover', backgroundImage: `url("${thumbnail}")` }}
+        style={{
+          backgroundColor: 'var(--gray-ml)',
+          backgroundSize: 'cover',
+          backgroundImage: `url("${thumbnail || '/assets/default-thumbnail.webp'}")`,
+        }}
       />
       <div className={styles.info}>
         <div>
           <div className={styles.title}>{title.length < 28 ? title : `${title.substring(0, 25).trim()}...`}</div>
-          <div className={styles.time}>{dateReader(finishedAt)}</div>
+          <div className={styles.time}>{finishedAt ? dateReader(finishedAt) : '응답 받는 중'}</div>
           <div className={styles.description}>{description}</div>
           <div className={styles.rewards}>
             {rewards.map((i) => (

--- a/src/components/main/survey-finder/item/Item.tsx
+++ b/src/components/main/survey-finder/item/Item.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import Link from 'next/link';
-import { FaArrowUp, FaGift } from 'react-icons/fa';
+import { FaGift } from 'react-icons/fa';
 import { dateReader } from '@/utils/dates';
+import Tooltip from '@/components/ui/tooltip/Tooltip';
 import type { Survey } from '../types';
 import styles from './Item.module.css';
-import RewardTag from './RewardTag';
 
 export default function ListItem({ survey }: { survey: Survey }) {
   const { surveyId, thumbnail, title, description, targetParticipants, rewardCount, finishedAt, rewards } = survey;
@@ -26,21 +26,19 @@ export default function ListItem({ survey }: { survey: Survey }) {
           <div className={styles.title}>{title}</div>
           <div className={styles.time}>{finishedAt ? dateReader(finishedAt) : '응답 받는 중'}</div>
           <div className={styles.description}>{description}</div>
-          <div className={styles.rewards}>
-            {rewards.map((i) => (
-              <RewardTag reward={i} key={i.category} />
-            ))}
-          </div>
         </div>
         <div className={styles.feasibility}>
           {rewardCount > 0 && (
             <div>
-              <FaGift /> {rewardCount}
-            </div>
-          )}
-          {targetParticipants !== null && (
-            <div>
-              <FaArrowUp /> {targetParticipants}
+              <Tooltip
+                text={`${rewards
+                  .map((reward) => {
+                    const { items } = reward;
+                    return items.join(', ');
+                  })
+                  .join(', ')}`}>
+                <FaGift /> {targetParticipants !== null ? '즉시 추첨' : '리워드 지급'}
+              </Tooltip>
             </div>
           )}
         </div>

--- a/src/components/main/survey-finder/types.ts
+++ b/src/components/main/survey-finder/types.ts
@@ -5,12 +5,12 @@ interface Reward {
 
 interface Survey {
   surveyId: string;
-  thumbnail: string;
+  thumbnail: string | null;
   title: string;
   description: string;
-  targetParticipants: number;
+  targetParticipants: number | null;
   rewardCount: number;
-  finishedAt: string;
+  finishedAt: string | null;
   rewards: Reward[];
 }
 

--- a/src/components/survey-details/Body.module.css
+++ b/src/components/survey-details/Body.module.css
@@ -1,0 +1,126 @@
+.body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  box-sizing: border-box;
+  width: 100%;
+  margin: 0 auto;
+  padding: 24px 18px;
+}
+
+.content {
+  display: inherit;
+  flex-direction: inherit;
+  box-sizing: border-box;
+  background-color: #fff;
+  width: 100%;
+  max-width: 420px;
+  border-radius: 4px;
+  padding: 18px;
+}
+
+.link {
+  text-align: center;
+  line-height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding-top: 12px;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.link > * {
+  color: var(--primary-alt);
+}
+
+.link > span {
+  font-size: 14px;
+  padding-right: 4px;
+}
+
+.link > span:hover {
+  text-decoration: underline;
+}
+
+.hr {
+  width: 100%;
+  height: 1px;
+  background-color: var(--gray-ml);
+  margin: 12px 0;
+  border: none;
+}
+
+.descriptor {
+  display: grid;
+  grid-template-columns: 36px 1fr;
+  column-gap: 4px;
+  align-items: start;
+  padding: 8px 0;
+}
+
+.descriptor > *:first-child {
+  justify-self: center;
+}
+
+.descriptor > *:last-child {
+  justify-self: center;
+  align-self: center;
+  width: 100%;
+}
+
+.status {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.status > * {
+  font-size: 16px;
+  line-height: 18px;
+  color: var(--gray);
+}
+
+.status > *:nth-child(1) {
+  font-size: 16px;
+  color: #000;
+}
+
+.status > *:last-child {
+  font-size: 14px;
+}
+
+.status > ul {
+  padding-left: 0;
+  margin-top: 4px;
+  margin-bottom: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.rewardInformation {
+  background-color: var(--gray-l);
+  padding: 8px;
+}
+
+.clause {
+  width: 100%;
+  max-width: 420px;
+  font-size: 12px;
+  color: var(--gray);
+  padding: 12px 0;
+  box-sizing: border-box;
+}
+
+.clause > h4 {
+  margin: 0;
+}
+
+.clause > ul {
+  list-style-type: disc;
+  margin: 0;
+  padding: 8px 24px;
+  box-sizing: border-box;
+}

--- a/src/components/survey-details/Body.tsx
+++ b/src/components/survey-details/Body.tsx
@@ -1,0 +1,108 @@
+import Button from '@/components/ui/button/Button';
+import { FaExternalLinkSquareAlt, FaGift, FaRegCalendarAlt } from 'react-icons/fa';
+import { GiSpeakerOff } from 'react-icons/gi';
+import moment from 'moment';
+import { FaPeopleGroup } from 'react-icons/fa6';
+import { Reward, RewardType } from '@/services/surveys/types';
+import Link from 'next/link';
+import styles from './Body.module.css';
+
+interface Props {
+  status: [string, string];
+  type: RewardType;
+  targetParticipantCount: number | null;
+  currentParticipantCount: number | null;
+  finishedAt: string | null;
+  rewards: Reward[];
+  onStart: () => void;
+}
+
+export default function Body({
+  status,
+  type,
+  targetParticipantCount,
+  currentParticipantCount,
+  finishedAt,
+  rewards,
+  onStart,
+}: Props) {
+  const StatusComponent =
+    status[0] === '응답 받는 중' ? undefined : (
+      <div className={styles.descriptor}>
+        <GiSpeakerOff size="24px" />
+        <div className={styles.status}>
+          <div>응답을 받지 않습니다.</div>
+          <div>
+            {status[0]}: {status[1]}
+          </div>
+        </div>
+      </div>
+    );
+
+  const RewardComponent = (() => {
+    if (type === 'NO_REWARD' || finishedAt === null) return undefined;
+
+    return (
+      <>
+        <div className={styles.descriptor}>
+          <FaGift size="20px" />
+          <div className={styles.status}>
+            {type === 'SELF_MANAGEMENT' && <div>리워드를 지급합니다.</div>}
+            {type === 'IMMEDIATE_DRAW' && <div>응답하면 즉시 추첨에 참여할 수 있습니다!</div>}
+            <ul>
+              {rewards.map((reward, i) => (
+                // eslint-disable-next-line react/no-array-index-key
+                <li key={i}>
+                  {reward.item} (x{reward.count})
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+        <div className={styles.descriptor}>
+          <FaRegCalendarAlt size="20px" />
+          <div className={styles.status}>
+            <div className={styles.endDate}>
+              {moment(finishedAt).format('YYYY년 MM월 DD일 hh시')}까지 응답을 받습니다.
+            </div>
+          </div>
+        </div>
+        {type === 'IMMEDIATE_DRAW' && currentParticipantCount !== null && targetParticipantCount !== null && (
+          <div className={styles.descriptor}>
+            <FaPeopleGroup size="20px" />
+            <div className={styles.status}>
+              <div className={styles.endDate}>
+                앞으로 {targetParticipantCount - currentParticipantCount}명이 추첨에 참여할 수 있습니다.
+              </div>
+            </div>
+          </div>
+        )}
+      </>
+    );
+  })();
+
+  return (
+    <div className={styles.body}>
+      <div className={styles.content}>
+        <Button variant="primary" width="100%" height="48px" onClick={onStart}>
+          참여하기
+        </Button>
+        <Link href="/" className={styles.link}>
+          <span>설문이용 메인으로</span>
+          <FaExternalLinkSquareAlt size="12px" />
+        </Link>
+        {(StatusComponent || RewardComponent) && <hr className={styles.hr} />}
+        {StatusComponent}
+        {RewardComponent}
+      </div>
+      <div className={styles.clause}>
+        <h4>리워드 관련 안내</h4>
+        <ul>
+          <li>낙첨된 경우 리워드는 지급되지 않습니다.</li>
+          <li>표시된 리워드와 수량은 설문 조사자가 지급하기로 약속한 내용입니다.</li>
+          <li>리워드 관련 분쟁에 대해 설문이용은 일체의 책임을 지지 않습니다.</li>
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/components/survey-details/Body.tsx
+++ b/src/components/survey-details/Body.tsx
@@ -97,14 +97,16 @@ export default function Body({
         {StatusComponent}
         {RewardComponent}
       </div>
-      <div className={styles.clause}>
-        <h4>리워드 관련 안내</h4>
-        <ul>
-          <li>낙첨된 경우 리워드는 지급되지 않습니다.</li>
-          <li>표시된 리워드와 수량은 설문 조사자가 지급하기로 약속한 내용입니다.</li>
-          <li>리워드 관련 분쟁에 대해 설문이용은 일체의 책임을 지지 않습니다.</li>
-        </ul>
-      </div>
+      {['IMMEDIATE_DRAW', 'SELF_MANAGEMENT'].includes(type) && (
+        <div className={styles.clause}>
+          <h4>리워드 관련 안내</h4>
+          <ul>
+            {type === 'IMMEDIATE_DRAW' && <li>낙첨된 경우 리워드는 지급되지 않습니다.</li>}
+            <li>표시된 리워드와 수량은 설문 조사자가 지급하기로 약속한 내용입니다.</li>
+            <li>리워드 관련 분쟁에 대해 설문이용은 일체의 책임을 지지 않습니다.</li>
+          </ul>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/survey-details/Body.tsx
+++ b/src/components/survey-details/Body.tsx
@@ -5,10 +5,11 @@ import moment from 'moment';
 import { FaPeopleGroup } from 'react-icons/fa6';
 import { Reward, RewardType } from '@/services/surveys/types';
 import Link from 'next/link';
+import { statusReader } from '@/utils/enumReader';
 import styles from './Body.module.css';
 
 interface Props {
-  status: [string, string];
+  status: string;
   type: RewardType;
   targetParticipantCount: number | null;
   currentParticipantCount: number | null;
@@ -26,14 +27,15 @@ export default function Body({
   rewards,
   onStart,
 }: Props) {
+  const [statusText, statusDetail] = statusReader(status);
   const StatusComponent =
-    status[0] === '응답 받는 중' ? undefined : (
+    status === 'IN_PROGRESS' ? undefined : (
       <div className={styles.descriptor}>
         <GiSpeakerOff size="24px" />
         <div className={styles.status}>
           <div>응답을 받지 않습니다.</div>
           <div>
-            {status[0]}: {status[1]}
+            {statusText}: {statusDetail}
           </div>
         </div>
       </div>
@@ -84,7 +86,7 @@ export default function Body({
   return (
     <div className={styles.body}>
       <div className={styles.content}>
-        <Button variant="primary" width="100%" height="48px" onClick={onStart}>
+        <Button variant="primary" width="100%" height="48px" onClick={onStart} disabled={status !== 'IN_PROGRESS'}>
           참여하기
         </Button>
         <Link href="/" className={styles.link}>

--- a/src/components/survey-details/Body.tsx
+++ b/src/components/survey-details/Body.tsx
@@ -7,6 +7,7 @@ import { Reward, RewardType } from '@/services/surveys/types';
 import Link from 'next/link';
 import { statusReader } from '@/utils/enumReader';
 import styles from './Body.module.css';
+import { getSurveyState } from '../survey-p/funcs/storage';
 
 interface Props {
   status: string;
@@ -16,6 +17,7 @@ interface Props {
   finishedAt: string | null;
   rewards: Reward[];
   onStart: () => void;
+  surveyId: string;
 }
 
 export default function Body({
@@ -26,7 +28,11 @@ export default function Body({
   finishedAt,
   rewards,
   onStart,
+  surveyId,
 }: Props) {
+  const isParticipated = getSurveyState(surveyId) === '$';
+  const isInProgress = status === 'IN_PROGRESS';
+
   const [statusText, statusDetail] = statusReader(status);
   const StatusComponent =
     status === 'IN_PROGRESS' ? undefined : (
@@ -83,11 +89,22 @@ export default function Body({
     );
   })();
 
+  const getParticipateButtonText = () => {
+    if (isParticipated) return '참여완료';
+    if (isInProgress) return '참여하기';
+    return '참여불가';
+  };
+
   return (
     <div className={styles.body}>
       <div className={styles.content}>
-        <Button variant="primary" width="100%" height="48px" onClick={onStart} disabled={status !== 'IN_PROGRESS'}>
-          참여하기
+        <Button
+          variant="primary"
+          width="100%"
+          height="48px"
+          onClick={onStart}
+          disabled={isParticipated || !isInProgress}>
+          {getParticipateButtonText()}
         </Button>
         <Link href="/" className={styles.link}>
           <span>설문이용 메인으로</span>

--- a/src/components/survey-details/Heads.module.css
+++ b/src/components/survey-details/Heads.module.css
@@ -20,6 +20,12 @@
   text-align: center;
 }
 
+.title {
+  width: 100%;
+  word-wrap: break-word;
+  word-break: break-word;
+}
+
 .description {
   width: 100%;
   text-align: center;
@@ -28,7 +34,8 @@
   outline: none;
   resize: none;
   color: var(--gray-d);
-  margin-bottom: 10px;
+  margin-bottom: 15px;
+  max-height: 300px;
 }
 
 .shareButton {
@@ -38,8 +45,8 @@
   padding: 8px 12px;
   border-radius: 4px;
   background-color: var(--gray-l);
-  border: none; /* new */
-  cursor: pointer; /* new */
+  border: none;
+  cursor: pointer;
   transition: background-color 0.2s cubic-bezier(0.075, 0.82, 0.165, 1);
 }
 

--- a/src/components/survey-details/Heads.module.css
+++ b/src/components/survey-details/Heads.module.css
@@ -1,0 +1,47 @@
+.heads {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  box-sizing: border-box;
+  width: 100%;
+  margin: 0 auto;
+  padding: 18px;
+  background-color: #fff;
+}
+
+.thumbnail {
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.title,
+.description {
+  max-width: 720px;
+  text-align: center;
+}
+
+.description {
+  width: 100%;
+  text-align: justify;
+  line-height: 22px;
+  border: none;
+  outline: none;
+  resize: none;
+  color: var(--gray-d);
+}
+
+.shareButton {
+  display: flex;
+  gap: 4px;
+  color: var(--gray-d);
+  padding: 8px 12px;
+  border-radius: 4px;
+  background-color: var(--gray-l);
+  border: none; /* new */
+  cursor: pointer; /* new */
+  transition: background-color 0.2s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+
+.shareButton:hover {
+  background-color: var(--gray-ml);
+}

--- a/src/components/survey-details/Heads.module.css
+++ b/src/components/survey-details/Heads.module.css
@@ -28,6 +28,7 @@
   outline: none;
   resize: none;
   color: var(--gray-d);
+  margin-bottom: 10px;
 }
 
 .shareButton {

--- a/src/components/survey-details/Heads.module.css
+++ b/src/components/survey-details/Heads.module.css
@@ -22,7 +22,7 @@
 
 .description {
   width: 100%;
-  text-align: justify;
+  text-align: center;
   line-height: 22px;
   border: none;
   outline: none;

--- a/src/components/survey-details/Heads.tsx
+++ b/src/components/survey-details/Heads.tsx
@@ -1,0 +1,51 @@
+import Image from 'next/image';
+import { FaCopy } from 'react-icons/fa';
+import React from 'react';
+import { writeClipboard } from '@/utils/misc';
+import { showToast } from '@/utils/toast';
+import styles from './Heads.module.css';
+
+interface Props {
+  title: string;
+  description: string;
+  thumbnail: string | null;
+}
+
+export default function Heads({ title, description, thumbnail }: Props) {
+  const resize = () => {
+    const textarea = document.getElementById('description');
+    if (!textarea) return;
+    textarea.style.height = 'auto';
+    textarea.style.height = `${textarea.scrollHeight}px`;
+  };
+
+  React.useEffect(() => {
+    resize();
+    window.addEventListener('resize', resize);
+    return () => window.removeEventListener('resize', resize);
+  }, []);
+
+  const copyUrl = () => {
+    writeClipboard(window.location.href);
+    showToast('success', '클립보드에 URL이 복사되었습니다!');
+  };
+
+  return (
+    <div className={styles.heads}>
+      <Image
+        className={styles.thumbnail}
+        src={thumbnail || '/assets/default-thumbnail.webp'}
+        alt="thumbnail"
+        width={220}
+        height={220}
+      />
+      <h2 className={styles.title}>{title}</h2>
+      {description?.length > 0 && (
+        <textarea id="description" className={styles.description} value={description} readOnly />
+      )}
+      <button type="button" className={styles.shareButton} onClick={() => copyUrl()}>
+        <FaCopy /> URL 복사
+      </button>
+    </div>
+  );
+}

--- a/src/components/survey-details/index.tsx
+++ b/src/components/survey-details/index.tsx
@@ -25,6 +25,7 @@ export default function DetailsViewer({ data, surveyId }: Props) {
         finishedAt={finishedAt}
         rewards={rewards}
         onStart={() => router.push(`/s/${surveyId}/p`)}
+        surveyId={surveyId}
       />
     </>
   );

--- a/src/components/survey-details/index.tsx
+++ b/src/components/survey-details/index.tsx
@@ -1,143 +1,32 @@
-import { FiActivity } from 'react-icons/fi';
-import { FaCalendarAlt, FaGift, FaInfoCircle, FaPaperclip } from 'react-icons/fa';
-import { FaUserGroup } from 'react-icons/fa6';
 import { useRouter } from 'next/navigation';
-import Link from 'next/link';
-import Wrapper from '@/components/layout/Wrapper';
-import Button from '@/components/ui/button/Button';
-import Tooltip from '@/components/ui/tooltip/Tooltip';
 import type { SurveysDetailsResponse } from '@/services/surveys/types';
-import { convertToKst } from '@/utils/dates';
-import { writeClipboard } from '@/utils/misc';
-import styles from './index.module.css';
-
-// TODO : utils로 이동
-const statusReader = (status: string) => {
-  switch (status) {
-    case 'IN_PROGRESS':
-      return ['응답 받는 중', '바로 참여할 수 있습니다.'];
-    case 'IN_MODIFICATION':
-      return ['편집 중', '편집 중인 설문조사는 참여할 수 없습니다.'];
-    case 'CLOSED':
-      return ['마감', '마감된 설문조사입니다.'];
-    default:
-      return ['알 수 없음', '알 수 없음'];
-  }
-};
+import { statusReader } from '@/utils/enumReader';
+import Heads from './Heads';
+import Body from './Body';
 
 interface Props {
   data: SurveysDetailsResponse;
   surveyId: string;
-  state: string | null;
 }
 
-export default function DetailsViewer({ data, surveyId, state }: Props) {
+export default function DetailsViewer({ data, surveyId }: Props) {
   const router = useRouter();
 
-  const {
-    title,
-    description,
-    status,
-    finishedAt: rawFinishedAt,
-    currentParticipants,
-    targetParticipants,
-    rewards,
-    thumbnail,
-  } = data;
-
-  const finishedAt = convertToKst(rawFinishedAt);
-
-  const copyUrl = () => {
-    writeClipboard(window.location.href);
-  };
-
-  const participate = () => {
-    router.push(`/s/${surveyId}/p`);
-  };
-
-  const [statusTitle, statusDescription] = statusReader(status);
+  const { title, description, status, type, finishedAt, currentParticipants, targetParticipants, rewards, thumbnail } =
+    data;
 
   return (
     <>
-      <Wrapper outerColor="#fff">
-        <div className={styles.image_headline}>
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img className={styles.image} src={thumbnail} alt="" width={180} height={180} />
-          <div className={styles.headline}>
-            <h1 className={styles.title}>{title}</h1>
-            <div className={styles.description}>{description}</div>
-          </div>
-        </div>
-        <div className={styles.share}>
-          <Button variant="default" onClick={() => copyUrl()}>
-            <FaPaperclip />
-            <span>URL 복사</span>
-          </Button>
-        </div>
-      </Wrapper>
-      <Wrapper>
-        <div className={styles.contentsWrapper}>
-          <div className={styles.contents}>
-            <div className={styles.participate}>
-              <Button
-                variant="primary"
-                width="100%"
-                height="46px"
-                onClick={() => participate()}
-                disabled={state === '$' || status !== 'IN_PROGRESS'}>
-                {state === '$' ? '참여 완료' : '참여하기'}
-              </Button>
-              <div>
-                <Link href="/">설문이용 메인으로</Link>
-              </div>
-            </div>
-            <hr className={styles.hr} />
-            <div className={styles.details}>
-              <div>
-                <FiActivity />
-                <div className={styles.status}>
-                  {statusTitle}
-                  <Tooltip text={statusDescription}>
-                    <FaInfoCircle />
-                  </Tooltip>
-                </div>
-              </div>
-              <div>
-                <FaCalendarAlt />
-                <div>
-                  {finishedAt.year}년 {finishedAt.month}월 {finishedAt.date}일 {finishedAt.hour}시 자동 마감
-                </div>
-              </div>
-              {targetParticipants != null && (
-                <div>
-                  <FaUserGroup />
-                  <div className={styles.participants}>
-                    <div>{currentParticipants}명 응답 완료</div>
-                    <div>/ 최대 {targetParticipants}명 응답 가능</div>
-                  </div>
-                </div>
-              )}
-              {rewards.length > 0 && (
-                <div>
-                  <FaGift />
-                  <div className={styles.rewards}>
-                    {rewards.map((reward) => (
-                      <div className={styles.reward} key={`${reward.item}`}>
-                        <div className={styles.item}>{reward.item}</div>
-                        <div className={styles.count}>x {reward.count}</div>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
-              <ul className={styles.clause}>
-                <li>* 설문 조사자가 지급을 약속한 리워드와 수량입니다.</li>
-                <li>* 리워드는 추첨을 퉁해 지급되며, 낙첨된 경우 지급되지 않습니다.</li>
-              </ul>
-            </div>
-          </div>
-        </div>
-      </Wrapper>
+      <Heads title={title} description={description} thumbnail={thumbnail} />
+      <Body
+        status={statusReader(status)}
+        type={type}
+        targetParticipantCount={targetParticipants}
+        currentParticipantCount={currentParticipants}
+        finishedAt={finishedAt}
+        rewards={rewards}
+        onStart={() => router.push(`/s/${surveyId}/p`)}
+      />
     </>
   );
 }

--- a/src/components/survey-details/index.tsx
+++ b/src/components/survey-details/index.tsx
@@ -1,6 +1,5 @@
 import { useRouter } from 'next/navigation';
 import type { SurveysDetailsResponse } from '@/services/surveys/types';
-import { statusReader } from '@/utils/enumReader';
 import Heads from './Heads';
 import Body from './Body';
 
@@ -19,7 +18,7 @@ export default function DetailsViewer({ data, surveyId }: Props) {
     <>
       <Heads title={title} description={description} thumbnail={thumbnail} />
       <Body
-        status={statusReader(status)}
+        status={status}
         type={type}
         targetParticipantCount={targetParticipants}
         currentParticipantCount={currentParticipants}

--- a/src/components/ui/tooltip/Tooltip.module.css
+++ b/src/components/ui/tooltip/Tooltip.module.css
@@ -6,7 +6,7 @@
 .tooltip {
   visibility: hidden;
   width: max-content; /* This will make it as wide as its content */
-  max-width: 300px; /* Optional: set a maximum width */
+  max-width: 400px; /* Optional: set a maximum width */
   background-color: #555;
   color: #fff;
   text-align: center;
@@ -20,6 +20,7 @@
   opacity: 0;
   transition: opacity 0.3s;
   white-space: nowrap; /* Prevent wrapping by default */
+  text-overflow: ellipsis;
 }
 
 .container:hover .tooltip {

--- a/src/services/surveys/types.ts
+++ b/src/services/surveys/types.ts
@@ -9,12 +9,12 @@ interface SurveysListResponse {
   pageCount: number;
   surveys: {
     surveyId: string;
-    thumbnail: string;
+    thumbnail: string | null;
     title: string;
     description: string;
-    targetParticipants: number;
+    targetParticipants: number | null;
     rewardCount: number;
-    finishedAt: string;
+    finishedAt: string | null;
     rewards: {
       category: string;
       items: string[];

--- a/src/services/surveys/types.ts
+++ b/src/services/surveys/types.ts
@@ -26,11 +26,19 @@ interface SurveysDetailsResponse {
   title: string;
   description: string;
   status: string;
-  finishedAt: string;
-  thumbnail: string;
-  currentParticipants: number;
-  targetParticipants: number;
-  rewards: { item: string; count: number }[];
+  type: RewardType;
+  finishedAt: string | null;
+  thumbnail: string | null;
+  currentParticipants: number | null;
+  targetParticipants: number | null;
+  rewards: Reward[];
+}
+
+type RewardType = 'NO_REWARD' | 'SELF_MANAGEMENT' | 'IMMEDIATE_DRAW';
+
+interface Reward {
+  item: string;
+  count: number;
 }
 
 type RDNumericalOrder = {
@@ -98,4 +106,6 @@ export type {
   SurveysResponseParams,
   SurveysResponseResponse,
   Question,
+  RewardType,
+  Reward,
 };


### PR DESCRIPTION
## 📢 설명

### 설문 상세 페이지 개선

- 미리보기와 같은 스타일로 설문 상세 페이지 수정
    
    ![image](https://github.com/user-attachments/assets/04dd2ebf-609c-42ec-942f-cf81ce5ca437)
    
- 설문 상세 페이지에서 제목이나 설명이 긴 경우 아래와 같이 표시
    
    ![image](https://github.com/user-attachments/assets/ad038351-5e3f-4f5c-950f-aa937c1cc3a8)
    
- 썸네일이 null이면 default 썸네일을 넣음
- URL 복사 버튼, 참여하기 버튼, 설문이용 메인으로 버튼 기능 정상화(미리보기에선 구현 안되어 있었음)

### 메인 페이지 개선

- 메인 페이지의 썸네일이 null이면 default 썸네일을 넣도록 수정
- 마감일이 없는 경우 “응답 받는 중”으로 표시
- 제목이나 설명이 긴 경우 처리 완료
- 리워드 툴팁을 제거하고, 기존에 리워드 수와 참여자 수 있던 자리에 추첨 방식 툴팁 추가
    
    ![image](https://github.com/user-attachments/assets/3b6d1543-0e11-44ae-82c4-0585dfffdbb6)
    

## ✅ 체크 리스트

- [x]  메인 페이지 화면의 해상도를 바꿔 가며 제목이나 설명이 긴 경우에도 css가 문제 없는지 확인
- [x]  추첨 방식 툴팁, 마감 일 등의 정보가 잘 나타나는지 확인
- [x]  제목과 설명이 긴 설문 참여 페이지로 접속했을 때 문제없이 잘 랜더링되는지 확인
    
    http://localhost:3000/s/ac9a9731-883b-420e-ad6b-2d0c7124bf18
    
- [x]  URL 복사, 메인으로, 참여하기 버튼 정상 동작 확인
- [x]  그 외 기타 사항 및 코드 리뷰