### PR TITLE
[SBL-170] workbench input 길이제한 추가

### DIFF
--- a/src/components/workbench/basics/main-section/index.tsx
+++ b/src/components/workbench/basics/main-section/index.tsx
@@ -39,9 +39,13 @@ export default function MainSection() {
             className={styles.input}
             value={title}
             onChange={handleChange}
+            maxLength={100}
             placeholder="설문지 제목을 입력하세요"
           />
         </label>
+        <div className={styles.maxLength}>
+          <span>{title.length} / 100자</span>
+        </div>
       </div>
 
       <div className={styles.group}>
@@ -53,9 +57,13 @@ export default function MainSection() {
             className={styles.textarea}
             value={description}
             onChange={handleChange}
+            maxLength={1000}
             placeholder="설문지 설명을 입력하세요"
           />
         </label>
+        <div className={styles.maxLength}>
+          <span>{description.length} / 1000자</span>
+        </div>
       </div>
 
       <Thumbnail />
@@ -69,9 +77,13 @@ export default function MainSection() {
             className={styles.textarea}
             value={finishMessage}
             onChange={handleChange}
+            maxLength={1000}
             placeholder="종료 메시지를 입력하세요"
           />
         </label>
+        <div className={styles.maxLength}>
+          <span>{finishMessage.length} / 1000자</span>
+        </div>
       </div>
     </>
   );

--- a/src/components/workbench/basics/main-section/index.tsx
+++ b/src/components/workbench/basics/main-section/index.tsx
@@ -57,12 +57,12 @@ export default function MainSection() {
             className={styles.textarea}
             value={description}
             onChange={handleChange}
-            maxLength={1000}
+            maxLength={2000}
             placeholder="설문지 설명을 입력하세요"
           />
         </label>
         <div className={styles.maxLength}>
-          <span>{description.length} / 1000자</span>
+          <span>{description.length} / 2000자</span>
         </div>
       </div>
 

--- a/src/components/workbench/basics/reward-section/list.module.css
+++ b/src/components/workbench/basics/reward-section/list.module.css
@@ -1,3 +1,15 @@
+.maxLength {
+  text-align: right;
+  font-size: 14px;
+}
+
+.maxLength > span {
+  color: var(--gray-md);
+  background-color: transparent;
+  padding: 2px 4px;
+  border-radius: 2px;
+}
+
 .rewardContainer {
   width: 100%;
   display: flex;

--- a/src/components/workbench/basics/reward-section/list.tsx
+++ b/src/components/workbench/basics/reward-section/list.tsx
@@ -35,11 +35,11 @@ function ModalContent({ action, apply, init }: ModalProps) {
   })();
 
   const categoryHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setCategory(e.target.value.trimStart().slice(0, 20));
+    setCategory(e.target.value.trimStart());
   };
 
   const nameHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setName(e.target.value.trimStart().slice(0, 40));
+    setName(e.target.value.trimStart());
   };
 
   const countHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -87,6 +87,7 @@ function ModalContent({ action, apply, init }: ModalProps) {
             placeholder="스타벅스 아메리카노 T"
             value={name}
             onChange={nameHandler}
+            maxLength={100}
           />
         </label>
         <div className={styles.maxLength}>

--- a/src/components/workbench/basics/reward-section/list.tsx
+++ b/src/components/workbench/basics/reward-section/list.tsx
@@ -70,8 +70,12 @@ function ModalContent({ action, apply, init }: ModalProps) {
             placeholder="커피, 치킨, 상품권..."
             value={category}
             onChange={categoryHandler}
+            maxLength={100}
           />
         </label>
+        <div className={styles.maxLength}>
+          <span>{category.length} / 100자</span>
+        </div>
       </div>
       <div className={styles.inputGroup}>
         <label htmlFor="new-reward-name" className={styles.label}>
@@ -85,6 +89,9 @@ function ModalContent({ action, apply, init }: ModalProps) {
             onChange={nameHandler}
           />
         </label>
+        <div className={styles.maxLength}>
+          <span>{name.length} / 100자</span>
+        </div>
       </div>
       <div className={styles.inputGroup}>
         <label htmlFor="new-reward-count" className={styles.label}>

--- a/src/components/workbench/basics/section.module.css
+++ b/src/components/workbench/basics/section.module.css
@@ -1,3 +1,15 @@
+.maxLength {
+  text-align: right;
+  font-size: 14px;
+}
+
+.maxLength > span {
+  color: var(--gray-md);
+  background-color: var(--gray-ml);
+  padding: 2px 4px;
+  border-radius: 2px;
+}
+
 .warning {
   background-color: var(--gray-ml);
   padding: 8px;

--- a/src/components/workbench/canvas/Field.tsx
+++ b/src/components/workbench/canvas/Field.tsx
@@ -30,6 +30,7 @@ function RenderTitle({ required, title, handleEdit, active }: TitleProps) {
         value={active || title !== '' ? title : '제목 없는 질문'}
         onChange={(e) => handleEdit({ title: e.target.value })}
         placeholder="질문을 입력해주세요."
+        maxLength={100}
       />
     </div>
   );
@@ -48,6 +49,7 @@ function RenderDescription({ description, handleEdit, active }: DescriptionProps
         value={active || description !== '' ? description : '질문 설명이 없습니다.'}
         onChange={(e) => handleEdit({ description: e.target.value })}
         placeholder="설명을 입력해주세요."
+        maxLength={1000}
       />
     </div>
   );
@@ -96,6 +98,7 @@ function RenderSelectableResponse({ type, options, handleEdit, active, other }: 
             value={active || content !== '' ? content : '빈 선택지'}
             onChange={(e) => handleContentEdit(id, e.target.value)}
             placeholder="선택지를 입력해주세요."
+            maxLength={100}
           />
           {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
           <button type="button" onClick={() => handleDelete(id)} className={styles.deleteSelectableResponseItem}>

--- a/src/components/workbench/canvas/Section.tsx
+++ b/src/components/workbench/canvas/Section.tsx
@@ -234,6 +234,7 @@ function SectionComponent({ section, index, isDraggingOver, activeState }: Props
                     className={styles.sectionTitle}
                     value={section.title}
                     placeholder="제목 없는 섹션"
+                    maxLength={100}
                     onChange={handleTitleChange}
                   />
                   <input
@@ -241,6 +242,7 @@ function SectionComponent({ section, index, isDraggingOver, activeState }: Props
                     className={styles.sectionDescription}
                     value={section.description}
                     placeholder="섹션 설명이 없습니다."
+                    maxLength={1000}
                     onChange={handleDescriptionChange}
                   />
                 </div>


### PR DESCRIPTION
## 📢 설명
workbench input 길이제한 추가

![image](https://github.com/user-attachments/assets/e237c4ae-99a9-4acb-ae49-ea8c341ce3f4)

![image](https://github.com/user-attachments/assets/8a016077-990e-48d8-b900-78b6a8daa7d7)

## ✅ 체크 리스트
기초 정보 탭
- [x] 설문 제목 100자
- [x] 설문 설명 1000자
- [x] 종료 메시지 1000자
- [x] 리워드 카테고리, 리워드 이름 100자

설문 작성 탭 (여기는 미관상 따로 추가로 표시되는 UI는 없습니다.)
- [x] 섹션 제목 100자
- [x] 섹션 설명 1000자
- [x] 질문 제목 100자
- [x] 질문 설명 1000자
- [x] 선택지 100자

설문 참여 화면은 이미 1000자 적용이 적용되어 있어 변동 없습니다.