### PR TITLE
[SBL-191] 인증을 세션 방식에서 JWT 방식으로 변경

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,10 +18,12 @@
         "chartjs-plugin-datalabels": "^2.2.0",
         "cookies-next": "^4.2.1",
         "immer": "^10.1.1",
+        "jsonwebtoken": "^9.0.2",
         "ky": "^1.5.0",
         "moment": "^2.30.1",
         "moment-timezone": "^0.5.45",
         "next": "14.2.4",
+        "nookies": "^2.5.2",
         "react": "^18",
         "react-chartjs-2": "^5.2.0",
         "react-datetime": "^3.2.0",
@@ -33,6 +35,7 @@
         "zustand": "^4.5.5"
       },
       "devDependencies": {
+        "@types/jsonwebtoken": "^9.0.7",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -1056,6 +1059,16 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.7.tgz",
+      "integrity": "sha512-ugo316mmTYBl2g81zDFnZ7cfxlut3o+/EQdaP7J8QN2kY6lJ22hmQYCK5EHcJHbrW+dkCGSCPgbG8JtYj6qSrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "20.14.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
@@ -1678,6 +1691,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -2231,6 +2250,15 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -4210,6 +4238,28 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -4223,6 +4273,27 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -4462,11 +4533,53 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
     },
     "node_modules/log-update": {
       "version": "6.0.0",
@@ -4715,8 +4828,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -4826,6 +4938,25 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/nookies": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/nookies/-/nookies-2.5.2.tgz",
+      "integrity": "sha512-x0TRSaosAEonNKyCrShoUaJ5rrT5KHRNZ5DwPCuizjgrnkpE5DRf3VL7AyyQin4htict92X1EQ7ejDbaHDVdYA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^0.4.1",
+        "set-cookie-parser": "^2.4.6"
+      }
+    },
+    "node_modules/nookies/node_modules/cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/normalize-path": {
@@ -5754,6 +5885,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safe-regex-test": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
@@ -5790,6 +5941,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.0.tgz",
+      "integrity": "sha512-lXLOiqpkUumhRdFF3k1osNXCy9akgx/dyPZ5p8qAg9seJzXr5ZrlqZuWIMuY6ejOsVLE6flJ5/h3lsn57fQ/PQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -20,10 +20,12 @@
     "chartjs-plugin-datalabels": "^2.2.0",
     "cookies-next": "^4.2.1",
     "immer": "^10.1.1",
+    "jsonwebtoken": "^9.0.2",
     "ky": "^1.5.0",
     "moment": "^2.30.1",
     "moment-timezone": "^0.5.45",
     "next": "14.2.4",
+    "nookies": "^2.5.2",
     "react": "^18",
     "react-chartjs-2": "^5.2.0",
     "react-datetime": "^3.2.0",
@@ -35,6 +37,7 @@
     "zustand": "^4.5.5"
   },
   "devDependencies": {
+    "@types/jsonwebtoken": "^9.0.7",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/src/app/(auth)/logout/page.tsx
+++ b/src/app/(auth)/logout/page.tsx
@@ -1,17 +1,14 @@
 'use client';
 
-import { useAuth } from '@/hooks/useAuth';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 
 export default function Page() {
   const { push } = useRouter();
-  const { logout } = useAuth();
 
   useEffect(() => {
-    logout();
     push(`${process.env.NEXT_PUBLIC_API_URL}/user/logout`);
-  }, [push, logout]);
+  }, [push]);
 
   return <div />;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -50,12 +50,12 @@ export default async function Layout({ children }: Readonly<{ children: React.Re
   const refreshTokenString = cookieStore.get('refresh-token')?.value;
   const refreshToken = getPayload(refreshTokenString);
 
-  // 엑세스 토큰과 리프레시 토큰이 유효하면 통과
-  if (accessToken && refreshToken && accessToken.sub && accessToken.nickname) {
+  // 엑세스 토큰이 유효하면 통과
+  if (accessToken && accessToken.sub && accessToken.nickname) {
     user = { id: accessToken.sub, nickname: accessToken.nickname };
   }
   // 리프레시 토큰은 유효한데 엑세스 토큰이 유효하지 않은 경우
-  else if (!accessToken && refreshToken) {
+  else if (refreshToken) {
     try {
       // 유저 프로필 API 호출해서 엑세스 토큰 재발급
       const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/user/profile`, {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import { cookies } from 'next/headers';
 import { GoogleAnalytics } from '@next/third-parties/google';
 
-import { decodeBase64 } from '@/utils/misc';
+import jwt from 'jsonwebtoken';
 import Providers from '@/providers/Providers';
 import type { User } from '@/providers/auth/types';
 
@@ -15,19 +15,60 @@ export const metadata: Metadata = {
   icons: { icon: '/assets/favicon.ico' },
 };
 
+function decodeBase64URL(value: string): Buffer {
+  let base64String = value.replace(/-/g, '+').replace(/_/g, '/');
+
+  const padding = base64String.length % 4;
+  if (padding === 2) {
+    base64String += '==';
+  } else if (padding === 3) {
+    base64String += '=';
+  }
+
+  return Buffer.from(base64String, 'base64');
+}
+
+const secret = decodeBase64URL(`${process.env.JWT_SECRET}`);
+
+function getPayload(token: string | undefined): jwt.JwtPayload | undefined {
+  if (!token) return undefined;
+  try {
+    const decodedToken = jwt.verify(token, secret);
+    if (typeof decodedToken === 'object') return decodedToken;
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
 export default async function Layout({ children }: Readonly<{ children: React.ReactNode }>) {
   const cookieStore = cookies();
   let user: undefined | User;
 
-  if (cookieStore.has('user-profile') && cookieStore.has('JSESSIONID')) {
+  const accessTokenString = cookieStore.get('access-token')?.value;
+  const accessToken = getPayload(accessTokenString);
+  const refreshTokenString = cookieStore.get('refresh-token')?.value;
+  const refreshToken = getPayload(refreshTokenString);
+
+  // 엑세스 토큰과 리프레시 토큰이 유효하면 통과
+  if (accessToken && refreshToken && accessToken.sub && accessToken.nickname) {
+    user = { id: accessToken.sub, nickname: accessToken.nickname };
+  }
+  // 리프레시 토큰은 유효한데 엑세스 토큰이 유효하지 않은 경우
+  else if (!accessToken && refreshToken) {
     try {
-      const { value } = cookieStore.get('user-profile')!;
-      const data = JSON.parse(decodeBase64(value));
-      if (typeof data !== 'object') throw new Error();
-      if (!data.nickname || typeof data.nickname !== 'string') throw new Error();
-      if (!data.id || typeof data.id !== 'string') throw new Error();
-      user = { nickname: data.nickname, id: data.id } as User;
-    } catch (e) {
+      // 유저 프로필 API 호출해서 엑세스 토큰 재발급
+      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/user/profile`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: `refresh-token=${refreshTokenString}`,
+        },
+        credentials: 'include',
+      });
+      const userProfile = await response.json();
+      if (userProfile.id && userProfile.nickname) user = userProfile;
+    } catch {
       user = undefined;
     }
   }

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,34 +1,10 @@
 'use client';
 
 import { useContext } from 'react';
-import { fetchUserProfile } from '@/services/user/fetch';
-import type { User } from '@/services/user/types';
 import { AuthContext } from '@/providers/auth/AuthProvider';
-import { useCookie } from './useCookie';
 
 export const useAuth = () => {
-  const { user, setUser } = useContext(AuthContext);
-  const { setCookie, getCookie, deleteCookie, hasCookie } = useCookie();
+  const { user } = useContext(AuthContext);
 
-  const refresh = async () => {
-    try {
-      const data = hasCookie('user-profile') ? JSON.parse(getCookie('user-profile')!) : null;
-      setUser(data || (await fetchUserProfile()));
-    } catch (e) {
-      setUser(null);
-    }
-  };
-
-  const login = (data: User) => {
-    // a function to call after login (i.e. /login/auth)
-    setCookie('user-profile', JSON.stringify(data));
-    refresh();
-  };
-
-  const logout = () => {
-    deleteCookie('user-profile');
-    refresh();
-  };
-
-  return { user, refresh, login, logout };
+  return { user };
 };

--- a/src/providers/auth/AuthProvider.tsx
+++ b/src/providers/auth/AuthProvider.tsx
@@ -1,8 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState, createContext } from 'react';
-import { useCookie } from '@/hooks/useCookie';
-import { decodeBase64 } from '@/utils/misc';
+import { useMemo, useState, createContext } from 'react';
 import type { User, AuthContext as AuthContextType } from './types';
 
 export const AuthContext = createContext<AuthContextType>({
@@ -11,26 +9,7 @@ export const AuthContext = createContext<AuthContextType>({
 });
 
 export default function AuthProvider({ children, init }: React.PropsWithChildren<{ init?: User }>) {
-  const { hasCookie, getCookie, deleteCookie } = useCookie();
   const [user, setUser] = useState<User | null>(init || null);
-
-  useEffect(() => {
-    (async () => {
-      if (user) return;
-      if (hasCookie('user-profile') && !hasCookie('JSESSIONID')) deleteCookie('user-profile');
-      if (hasCookie('user-profile')) {
-        try {
-          const data = JSON.parse(decodeBase64(getCookie('user-profile')!));
-          if (typeof data !== 'object') throw new Error();
-          if (!data.nickname || typeof data.nickname !== 'string') throw new Error();
-          if (!data.id || typeof data.id !== 'string') throw new Error();
-          setUser({ nickname: data.nickname, id: data.id });
-        } catch (e) {
-          setUser(null);
-        }
-      }
-    })();
-  }, [getCookie, hasCookie, user]);
 
   const contextValue = useMemo(
     () => ({

--- a/src/services/ky-wrapper.ts
+++ b/src/services/ky-wrapper.ts
@@ -3,6 +3,12 @@ import ky, { HTTPError, type KyInstance, type Options } from 'ky';
 const beforeError = async (error: HTTPError) => {
   const res = error;
 
+  if (res.response.status === 401) {
+    // eslint-disable-next-line no-alert
+    alert('로그인이 필요합니다!');
+    window.location.href = '/login';
+  }
+
   try {
     res.cause = await error.response.json<ErrorCause>();
   } catch (e) {


### PR DESCRIPTION
## 📢 설명
인증을 세션 방식에서 JWT 방식으로 변경

### 클라이언트 변경 사항
1. 최상위 서버 컴포넌트 Layout에서 엑세스 토큰 쿠키와 리프레시 토큰 쿠키를 읽어서 유저 정보 업데이트
2. 하위 컴포넌트들에서 기존 JSESSION_ID와 user-profile 쿠키를 읽는 로직 제거
3. 401 에러 발생 시(비 로그인 상태 or 리프레시 토큰이 유효하지 않은 상태) alert 발생 후 로그인 페이지로 리디렉트

## ✅ 체크 리스트
- [x] 노션 참고하여 프론트엔드 .env.local 업데이트 하기(JWT_SECRET 추가)
- [x] https://github.com/SUIN-BUNDANG-LINE/Backend/pull/93 와 연계하여 테스트 진행
