### PR TITLE
[SBL-200] 설문 통계 공개 기능 구현

### DIFF
--- a/src/app/management/[id]/page.tsx
+++ b/src/app/management/[id]/page.tsx
@@ -78,7 +78,7 @@ export default function Page({ params }: { params: { id: string } }) {
 
   return (
     <div className={styles.app}>
-      <Header tab={tab} tabHandler={tabHandler} title={data?.title} isGuest={isGuest} />
+      <Header tab={tab} tabHandler={tabHandler} title={data?.title} isGuest={isGuest} surveyId={id} />
       {content}
       <div className={styles.footer}>
         <Footer />

--- a/src/app/management/[id]/page.tsx
+++ b/src/app/management/[id]/page.tsx
@@ -7,6 +7,9 @@ import { useGetSurvey } from '@/components/workbench/service';
 import Header from '@/components/management/ui/Header';
 import { showToast } from '@/utils/toast';
 import { Footer } from '@/components/layout/main';
+import { useVisitorData } from '@fingerprintjs/fingerprintjs-pro-react';
+import Loading from '@/components/ui/loading/Loading';
+import Error from '@/components/ui/error/Error';
 import styles from './page.module.css';
 import Tab0 from './tab0';
 import Tab1 from './tab1';
@@ -23,8 +26,15 @@ export default function Page({ params }: { params: { id: string } }) {
   const router = useRouter();
   const { id } = params;
 
+  const {
+    isLoading: visitorLoading,
+    error: visitorError,
+    data: visitorData,
+  } = useVisitorData({ extendedResult: true }, { immediate: true });
+
   const searchParams = useSearchParams();
   const [tab, setTab] = React.useState(getTabFromSearchParams(searchParams));
+  const isGuest = searchParams.get('isGuest') === 'true';
   const { data } = useGetSurvey(id);
 
   const tabHandler = (newTab: number) => {
@@ -39,14 +49,36 @@ export default function Page({ params }: { params: { id: string } }) {
   }
 
   let content;
-  if (tab === 0) content = <Tab0 surveyId={id} />;
-  else if (tab === 1) content = <Tab1 surveyId={id} setTab={setTab} />;
-  else if (tab === 2) content = <Tab2 surveyId={id} participantId={searchParams.get('participantId')} />;
-  else if (tab === 3) content = <Tab3 surveyId={id} initialIsFinished={data ? data.status === 'CLOSED' : undefined} />;
+
+  if (isGuest && visitorLoading)
+    content = (
+      <div className={styles.loading}>
+        <Loading message="데이터를 불러오는 중..." />
+      </div>
+    );
+  else if (isGuest && visitorError)
+    content = (
+      <div className={styles.error}>
+        <Error message="데이터를 불러오지 못했습니다." buttons={[]} margin="18px" />
+      </div>
+    );
+  else if (tab === 0) content = <Tab0 surveyId={id} visitorId={isGuest ? visitorData?.visitorId : undefined} />;
+  else if (tab === 1)
+    content = <Tab1 surveyId={id} setTab={setTab} visitorId={isGuest ? visitorData?.visitorId : undefined} />;
+  else if (tab === 2)
+    content = (
+      <Tab2
+        surveyId={id}
+        participantId={searchParams.get('participantId')}
+        visitorId={isGuest ? visitorData?.visitorId : undefined}
+      />
+    );
+  else if (tab === 3 && !isGuest)
+    content = <Tab3 surveyId={id} initialIsFinished={data ? data.status === 'CLOSED' : undefined} />;
 
   return (
     <div className={styles.app}>
-      <Header tab={tab} tabHandler={tabHandler} title={data?.title} />
+      <Header tab={tab} tabHandler={tabHandler} title={data?.title} isGuest={isGuest} />
       {content}
       <div className={styles.footer}>
         <Footer />

--- a/src/app/management/[id]/page.tsx
+++ b/src/app/management/[id]/page.tsx
@@ -34,7 +34,7 @@ export default function Page({ params }: { params: { id: string } }) {
 
   const searchParams = useSearchParams();
   const [tab, setTab] = React.useState(getTabFromSearchParams(searchParams));
-  const isGuest = searchParams.get('isGuest') === 'true';
+  const isGuest = searchParams.get('guest') === 'true';
   const { data } = useGetSurvey(id);
 
   const tabHandler = (newTab: number) => {

--- a/src/app/management/[id]/tab0.tsx
+++ b/src/app/management/[id]/tab0.tsx
@@ -8,10 +8,10 @@ import Error from '@/components/ui/error/Error';
 import FilterManager from '@/components/management/result/FilterManager';
 import styles from './tab0.module.css';
 
-export default function Tab0({ surveyId }: { surveyId: string }) {
+export default function Tab0({ surveyId, visitorId }: { surveyId: string; visitorId: string | undefined }) {
   const [resultFilter, setResultFilter] = useState<ResultFilter>({ questionFilters: [] });
   const [isManualSearch, setIsManualSearch] = useState(false);
-  const { data, isLoading, isError, refetch } = useSurveyResult(surveyId, resultFilter, undefined);
+  const { data, isLoading, isError, refetch } = useSurveyResult(surveyId, resultFilter, undefined, visitorId);
 
   const handleSearch = (filters: QuestionFilter[]) => {
     setResultFilter({ questionFilters: filters });

--- a/src/app/management/[id]/tab1.tsx
+++ b/src/app/management/[id]/tab1.tsx
@@ -48,7 +48,7 @@ export default function Tab1({
         targetParticipant={targetParticipant}
         winningCount={winners.length}
       />
-      {isImmediateDraw && <WinnerList winners={winners} />}
+      {isImmediateDraw && !visitorId && <WinnerList winners={winners} />}
       <ParticipantList participants={participants} setTab={setTab} />
     </div>
   );

--- a/src/app/management/[id]/tab1.tsx
+++ b/src/app/management/[id]/tab1.tsx
@@ -11,11 +11,13 @@ import styles from './tab1.module.css';
 export default function Tab1({
   surveyId,
   setTab,
+  visitorId,
 }: {
   surveyId: string;
   setTab: React.Dispatch<React.SetStateAction<number>>;
+  visitorId: string | undefined;
 }) {
-  const { data, isLoading, isError, refetch } = useParticipants(surveyId);
+  const { data, isLoading, isError, refetch } = useParticipants(surveyId, visitorId);
 
   if (isLoading)
     return (

--- a/src/app/management/[id]/tab2.tsx
+++ b/src/app/management/[id]/tab2.tsx
@@ -10,13 +10,21 @@ import Loading from '@/components/ui/loading/Loading';
 import Error from '@/components/ui/error/Error';
 import styles from './tab2.module.css';
 
-export default function Tab2({ surveyId, participantId }: { surveyId: string; participantId: string | null }) {
+export default function Tab2({
+  surveyId,
+  participantId,
+  visitorId,
+}: {
+  surveyId: string;
+  participantId: string | null;
+  visitorId: string | undefined;
+}) {
   const {
     data: participantData,
     isLoading: participantsIsLoading,
     isError: participantsIsError,
     refetch: participantsRefetch,
-  } = useParticipants(surveyId);
+  } = useParticipants(surveyId, visitorId);
 
   const participants = useMemo(() => {
     return participantData?.participants || [];
@@ -50,6 +58,7 @@ export default function Tab2({ surveyId, participantId }: { surveyId: string; pa
     surveyId,
     { questionFilters: [] },
     currentParticipantId,
+    visitorId,
     {
       enabled: !!currentParticipantId, // currentParticipantId가 있을 때만 쿼리 실행
     }

--- a/src/components/main/survey-finder/item/Item.tsx
+++ b/src/components/main/survey-finder/item/Item.tsx
@@ -34,7 +34,7 @@ export default function ListItem({ survey }: { survey: Survey }) {
       />
       <div className={styles.info}>
         <div>
-          <div className={styles.title}>{title}</div>
+          <div className={styles.title}>{title || '제목 없는 설문'}</div>
           <div className={styles.time}>{finishedAt ? dateReader(finishedAt) : '응답 받는 중'}</div>
           <div className={styles.description}>{description}</div>
         </div>

--- a/src/components/main/survey-finder/item/Item.tsx
+++ b/src/components/main/survey-finder/item/Item.tsx
@@ -4,11 +4,22 @@ import Link from 'next/link';
 import { FaGift } from 'react-icons/fa';
 import { dateReader } from '@/utils/dates';
 import Tooltip from '@/components/ui/tooltip/Tooltip';
+import { FaChartSimple } from 'react-icons/fa6';
 import type { Survey } from '../types';
 import styles from './Item.module.css';
 
 export default function ListItem({ survey }: { survey: Survey }) {
-  const { surveyId, thumbnail, title, description, targetParticipants, rewardCount, finishedAt, rewards } = survey;
+  const {
+    surveyId,
+    thumbnail,
+    title,
+    description,
+    targetParticipants,
+    rewardCount,
+    finishedAt,
+    rewards,
+    isResultOpen,
+  } = survey;
 
   return (
     // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
@@ -28,6 +39,13 @@ export default function ListItem({ survey }: { survey: Survey }) {
           <div className={styles.description}>{description}</div>
         </div>
         <div className={styles.feasibility}>
+          {isResultOpen && (
+            <div>
+              <Tooltip text="설문 참여 후 설문의 통계를 볼 수 있습니다.">
+                <FaChartSimple /> 통계 공개
+              </Tooltip>
+            </div>
+          )}
           {rewardCount > 0 && (
             <div>
               <Tooltip

--- a/src/components/main/survey-finder/types.ts
+++ b/src/components/main/survey-finder/types.ts
@@ -11,6 +11,7 @@ interface Survey {
   targetParticipants: number | null;
   rewardCount: number;
   finishedAt: string | null;
+  isResultOpen: boolean;
   rewards: Reward[];
 }
 

--- a/src/components/management/ui/Header.tsx
+++ b/src/components/management/ui/Header.tsx
@@ -6,9 +6,10 @@ type Props = {
   tab: number;
   tabHandler: (newTab: number) => void;
   title: string | undefined;
+  isGuest: boolean;
 };
 
-export default function Header({ tab, tabHandler, title }: Props) {
+export default function Header({ tab, tabHandler, title, isGuest }: Props) {
   const tabData = [
     {
       label: '통계 보기',
@@ -22,11 +23,13 @@ export default function Header({ tab, tabHandler, title }: Props) {
       label: '개별 응답',
       path: 'M240-80q-50 0-85-35t-35-85v-120h120v-560h600v680q0 50-35 85t-85 35H240Zm480-80q17 0 28.5-11.5T760-200v-600H320v480h360v120q0 17 11.5 28.5T720-160ZM360-600v-80h360v80H360Zm0 120v-80h360v80H360ZM240-160h360v-80H200v40q0 17 11.5 28.5T240-160Zm0 0h-40 400-360Z',
     },
-    {
+  ];
+
+  if (!isGuest)
+    tabData.push({
       label: '설정',
       path: 'm370-80-16-128q-13-5-24.5-12T307-235l-119 50L78-375l103-78q-1-7-1-13.5v-27q0-6.5 1-13.5L78-585l110-190 119 50q11-8 23-15t24-12l16-128h220l16 128q13 5 24.5 12t22.5 15l119-50 110 190-103 78q1 7 1 13.5v27q0 6.5-2 13.5l103 78-110 190-118-50q-11 8-23 15t-24 12L590-80H370Zm70-80h79l14-106q31-8 57.5-23.5T639-327l99 41 39-68-86-65q5-14 7-29.5t2-31.5q0-16-2-31.5t-7-29.5l86-65-39-68-99 42q-22-23-48.5-38.5T533-694l-13-106h-79l-14 106q-31 8-57.5 23.5T321-633l-99-41-39 68 86 64q-5 15-7 30t-2 32q0 16 2 31t7 30l-86 65 39 68 99-42q22 23 48.5 38.5T427-266l13 106Zm42-180q58 0 99-41t41-99q0-58-41-99t-99-41q-59 0-99.5 41T342-480q0 58 40.5 99t99.5 41Zm-2-140Z',
-    },
-  ];
+    });
 
   return (
     <div className={styles.wrapper}>

--- a/src/components/management/ui/Header.tsx
+++ b/src/components/management/ui/Header.tsx
@@ -7,9 +7,10 @@ type Props = {
   tabHandler: (newTab: number) => void;
   title: string | undefined;
   isGuest: boolean;
+  surveyId: string;
 };
 
-export default function Header({ tab, tabHandler, title, isGuest }: Props) {
+export default function Header({ tab, tabHandler, title, isGuest, surveyId }: Props) {
   const tabData = [
     {
       label: '통계 보기',
@@ -35,7 +36,7 @@ export default function Header({ tab, tabHandler, title, isGuest }: Props) {
     <div className={styles.wrapper}>
       <div className={styles.header}>
         <div className={styles.first}>
-          <Link href="/mypage">
+          <Link href={isGuest ? `/s/${surveyId}` : '/mypage'}>
             <svg xmlns="http://www.w3.org/2000/svg" height="42px" viewBox="0 -960 960 960" width="42px" fill="#5f6368">
               <path d="m313-440 224 224-57 56-320-320 320-320 57 56-224 224h487v80H313Z" />
             </svg>

--- a/src/components/survey-details/Body.module.css
+++ b/src/components/survey-details/Body.module.css
@@ -124,3 +124,12 @@
   padding: 8px 24px;
   box-sizing: border-box;
 }
+
+.viewResultButton {
+  background-color: #0070F3; /* 배경색 */
+  color: #FFFFFF; /* 폰트 색 */
+}
+
+.viewResultButton:hover {
+  background-color: #0056b3;
+}

--- a/src/components/survey-details/Body.tsx
+++ b/src/components/survey-details/Body.tsx
@@ -53,8 +53,10 @@ export default function Body({
 
   const ResultOpenComponent = isResultOpen ? (
     <div className={styles.descriptor}>
-      <FaChartSimple size="24px" />
-      <div className={styles.status}>설문에 참여한 뒤 통계를 볼 수 있습니다!</div>
+      <FaChartSimple size="20px" />
+      <div className={styles.status} style={{ fontSize: '14px' }}>
+        설문에 참여한 뒤 통계를 볼 수 있습니다!
+      </div>
     </div>
   ) : undefined;
 
@@ -128,8 +130,8 @@ export default function Body({
         </Link>
         {(StatusComponent || RewardComponent || ResultOpenComponent) && <hr className={styles.hr} />}
         {StatusComponent}
-        {ResultOpenComponent}
         {RewardComponent}
+        {ResultOpenComponent}
       </div>
       {['IMMEDIATE_DRAW', 'SELF_MANAGEMENT'].includes(type) && (
         <div className={styles.clause}>

--- a/src/components/survey-details/Body.tsx
+++ b/src/components/survey-details/Body.tsx
@@ -2,7 +2,7 @@ import Button from '@/components/ui/button/Button';
 import { FaExternalLinkSquareAlt, FaGift, FaRegCalendarAlt } from 'react-icons/fa';
 import { GiSpeakerOff } from 'react-icons/gi';
 import moment from 'moment';
-import { FaPeopleGroup } from 'react-icons/fa6';
+import { FaChartSimple, FaPeopleGroup } from 'react-icons/fa6';
 import { Reward, RewardType } from '@/services/surveys/types';
 import Link from 'next/link';
 import { statusReader } from '@/utils/enumReader';
@@ -17,7 +17,9 @@ interface Props {
   finishedAt: string | null;
   rewards: Reward[];
   onStart: () => void;
+  onClickResultButton: () => void;
   surveyId: string;
+  isResultOpen: boolean;
 }
 
 export default function Body({
@@ -29,6 +31,8 @@ export default function Body({
   rewards,
   onStart,
   surveyId,
+  isResultOpen,
+  onClickResultButton,
 }: Props) {
   const isParticipated = getSurveyState(surveyId) === '$';
   const isInProgress = status === 'IN_PROGRESS';
@@ -46,6 +50,13 @@ export default function Body({
         </div>
       </div>
     );
+
+  const ResultOpenComponent = isResultOpen ? (
+    <div className={styles.descriptor}>
+      <FaChartSimple size="24px" />
+      <div className={styles.status}>설문에 참여한 뒤 통계를 볼 수 있습니다!</div>
+    </div>
+  ) : undefined;
 
   const RewardComponent = (() => {
     if (type === 'NO_REWARD' || finishedAt === null) return undefined;
@@ -106,12 +117,24 @@ export default function Body({
           disabled={isParticipated || !isInProgress}>
           {getParticipateButtonText()}
         </Button>
+        {isResultOpen && (
+          <Button
+            variant="primary"
+            width="100%"
+            height="48px"
+            onClick={onClickResultButton}
+            disabled={!isParticipated && isInProgress}
+            style={{ marginTop: '12px', backgroundColor: '#0070f3', color: 'white' }}>
+            통계 보기
+          </Button>
+        )}
         <Link href="/" className={styles.link}>
           <span>설문이용 메인으로</span>
           <FaExternalLinkSquareAlt size="12px" />
         </Link>
-        {(StatusComponent || RewardComponent) && <hr className={styles.hr} />}
+        {(StatusComponent || RewardComponent || ResultOpenComponent) && <hr className={styles.hr} />}
         {StatusComponent}
+        {ResultOpenComponent}
         {RewardComponent}
       </div>
       {['IMMEDIATE_DRAW', 'SELF_MANAGEMENT'].includes(type) && (

--- a/src/components/survey-details/Body.tsx
+++ b/src/components/survey-details/Body.tsx
@@ -17,7 +17,7 @@ interface Props {
   finishedAt: string | null;
   rewards: Reward[];
   onStart: () => void;
-  onClickResultButton: () => void;
+  viewResult: () => void;
   surveyId: string;
   isResultOpen: boolean;
 }
@@ -32,7 +32,7 @@ export default function Body({
   onStart,
   surveyId,
   isResultOpen,
-  onClickResultButton,
+  viewResult,
 }: Props) {
   const isParticipated = getSurveyState(surveyId) === '$';
   const isInProgress = status === 'IN_PROGRESS';
@@ -101,7 +101,9 @@ export default function Body({
   })();
 
   const getParticipateButtonText = () => {
-    if (isParticipated) return '참여완료';
+    if (isParticipated) {
+      return isResultOpen ? '통계보기' : '참여완료';
+    }
     if (isInProgress) return '참여하기';
     return '참여불가';
   };
@@ -113,21 +115,13 @@ export default function Body({
           variant="primary"
           width="100%"
           height="48px"
-          onClick={onStart}
-          disabled={isParticipated || !isInProgress}>
+          onClick={() => {
+            if (isParticipated && isResultOpen) viewResult();
+            else onStart();
+          }}
+          disabled={(isParticipated && !isResultOpen) || !isInProgress}>
           {getParticipateButtonText()}
         </Button>
-        {isResultOpen && (
-          <Button
-            variant="primary"
-            width="100%"
-            height="48px"
-            onClick={onClickResultButton}
-            disabled={!isParticipated && isInProgress}
-            style={{ marginTop: '12px', backgroundColor: '#0070f3', color: 'white' }}>
-            통계 보기
-          </Button>
-        )}
         <Link href="/" className={styles.link}>
           <span>설문이용 메인으로</span>
           <FaExternalLinkSquareAlt size="12px" />

--- a/src/components/survey-details/index.tsx
+++ b/src/components/survey-details/index.tsx
@@ -11,8 +11,18 @@ interface Props {
 export default function DetailsViewer({ data, surveyId }: Props) {
   const router = useRouter();
 
-  const { title, description, status, type, finishedAt, currentParticipants, targetParticipants, rewards, thumbnail } =
-    data;
+  const {
+    title,
+    description,
+    status,
+    type,
+    finishedAt,
+    currentParticipants,
+    targetParticipants,
+    rewards,
+    thumbnail,
+    isResultOpen,
+  } = data;
 
   return (
     <>
@@ -26,6 +36,8 @@ export default function DetailsViewer({ data, surveyId }: Props) {
         rewards={rewards}
         onStart={() => router.push(`/s/${surveyId}/p`)}
         surveyId={surveyId}
+        isResultOpen={isResultOpen}
+        onClickResultButton={() => router.push(`/management/${surveyId}?isGuest=true`)}
       />
     </>
   );

--- a/src/components/survey-details/index.tsx
+++ b/src/components/survey-details/index.tsx
@@ -39,7 +39,7 @@ export default function DetailsViewer({ data, surveyId }: Props) {
         }}
         surveyId={surveyId}
         isResultOpen={isResultOpen}
-        viewResult={() => router.push(`/management/${surveyId}?isGuest=true`)}
+        viewResult={() => router.push(`/management/${surveyId}?guest=true`)}
       />
     </>
   );

--- a/src/components/survey-details/index.tsx
+++ b/src/components/survey-details/index.tsx
@@ -34,10 +34,12 @@ export default function DetailsViewer({ data, surveyId }: Props) {
         currentParticipantCount={currentParticipants}
         finishedAt={finishedAt}
         rewards={rewards}
-        onStart={() => router.push(`/s/${surveyId}/p`)}
+        onStart={() => {
+          router.push(`/s/${surveyId}/p`);
+        }}
         surveyId={surveyId}
         isResultOpen={isResultOpen}
-        onClickResultButton={() => router.push(`/management/${surveyId}?isGuest=true`)}
+        viewResult={() => router.push(`/management/${surveyId}?isGuest=true`)}
       />
     </>
   );

--- a/src/components/workbench/basics/main-section/index.tsx
+++ b/src/components/workbench/basics/main-section/index.tsx
@@ -8,6 +8,7 @@ export default function MainSection() {
     description: state.description,
     finishMessage: state.finishMessage,
     isVisible: state.isVisible,
+    isResultOpen: state.isResultOpen,
     setter: state.setter,
   }));
 

--- a/src/components/workbench/basics/misc-section/index.tsx
+++ b/src/components/workbench/basics/misc-section/index.tsx
@@ -31,7 +31,8 @@ export default function MiscSection() {
         설문 통계 공개
       </label>
       <div className={styles.description}>설문 참여자가 설문 참여 후 설문의 통계를 볼 수 있습니다.</div>
-      <hr />
+      <br />
+      <br />
       <label className={styles.checkboxLabel} htmlFor="survey-is-visible">
         <input
           id="survey-is-visible"

--- a/src/components/workbench/basics/misc-section/index.tsx
+++ b/src/components/workbench/basics/misc-section/index.tsx
@@ -28,9 +28,9 @@ export default function MiscSection() {
           checked={isResultOpen}
           onChange={isResultOpenChangeHandler}
         />
-        설문 결과 공개
+        설문 통계 공개
       </label>
-      <div className={styles.description}>설문 참여자가 설문 참여 후 설문의 결과를 볼 수 있습니다.</div>
+      <div className={styles.description}>설문 참여자가 설문 참여 후 설문의 통계를 볼 수 있습니다.</div>
       <hr />
       <label className={styles.checkboxLabel} htmlFor="survey-is-visible">
         <input

--- a/src/components/workbench/basics/misc-section/index.tsx
+++ b/src/components/workbench/basics/misc-section/index.tsx
@@ -3,17 +3,35 @@ import { useSurveyStore } from '../../store';
 import styles from './index.module.css';
 
 export default function MiscSection() {
-  const { isVisible, setter } = useSurveyStore((state) => ({
+  const { isVisible, isResultOpen, setter } = useSurveyStore((state) => ({
     isVisible: state.isVisible,
+    isResultOpen: state.isResultOpen,
     setter: state.setter,
   }));
 
-  const changeHandler = () => {
+  const isResultOpenChangeHandler = () => {
+    setter({ key: 'isResultOpen', value: !isResultOpen });
+  };
+
+  const isVisibleChangeHandler = () => {
     setter({ key: 'isVisible', value: !isVisible });
   };
 
   return (
     <div className={styles.group}>
+      <label className={styles.checkboxLabel} htmlFor="survey-is-result">
+        <input
+          id="survey-is-result-open"
+          type="checkbox"
+          name="isResultOpen"
+          className={styles.checkbox}
+          checked={isResultOpen}
+          onChange={isResultOpenChangeHandler}
+        />
+        설문 결과 공개
+      </label>
+      <div className={styles.description}>설문 참여자가 설문 참여 후 설문의 결과를 볼 수 있습니다.</div>
+      <hr />
       <label className={styles.checkboxLabel} htmlFor="survey-is-visible">
         <input
           id="survey-is-visible"
@@ -21,7 +39,7 @@ export default function MiscSection() {
           name="isVisible"
           className={styles.checkbox}
           checked={isVisible}
-          onChange={changeHandler}
+          onChange={isVisibleChangeHandler}
         />
         설문지를 설문이용에 공개하는데 동의합니다. (권장)
       </label>

--- a/src/components/workbench/func/convert.ts
+++ b/src/components/workbench/func/convert.ts
@@ -164,7 +164,8 @@ const cout = (store: Store): OutgoingSurvey => {
     }
   };
 
-  const { title, description, thumbnail, finishMessage, isVisible, rewardConfig, sections, fields } = store;
+  const { title, description, thumbnail, finishMessage, isVisible, isResultOpen, rewardConfig, sections, fields } =
+    store;
 
   return {
     title,
@@ -172,6 +173,7 @@ const cout = (store: Store): OutgoingSurvey => {
     thumbnail,
     finishMessage,
     isVisible,
+    isResultOpen,
     rewardSetting: normalizeReward(rewardConfig),
     sections: getSections(sections, fields),
   };

--- a/src/components/workbench/func/index.ts
+++ b/src/components/workbench/func/index.ts
@@ -11,6 +11,7 @@ export const extractStore = (state: Store & Actions) => ({
   finishMessage: state.finishMessage,
   status: state.status,
   isVisible: state.isVisible,
+  isResultOpen: state.isResultOpen,
   rewardConfig: state.rewardConfig,
   sections: state.sections,
   fields: state.fields,

--- a/src/components/workbench/service/fetch.ts
+++ b/src/components/workbench/service/fetch.ts
@@ -11,7 +11,7 @@ const fetchSurveyPut = async ({ surveyId, survey }: { surveyId: string; survey: 
 };
 
 const fetchSurveyGet = async ({ surveyId }: { surveyId: string }) => {
-  return kyWrapper.get<ImportedSurvey>(makeUrl(['surveys', 'workbench', surveyId]));
+  return kyWrapper.get<ImportedSurvey>(makeUrl(['surveys', 'make-info', surveyId]));
 };
 
 const fetchSurveyStart = async ({ surveyId }: { surveyId: string }) => {

--- a/src/components/workbench/store/index.ts
+++ b/src/components/workbench/store/index.ts
@@ -41,6 +41,7 @@ const DEFAULT_STORE: Store = {
   finishMessage: '',
   status: 'NOT_STARTED' as const,
   isVisible: true,
+  isResultOpen: false,
   publishedAt: null,
 
   rewardConfig: {

--- a/src/components/workbench/types/query.ts
+++ b/src/components/workbench/types/query.ts
@@ -10,6 +10,7 @@ type ImportedSurvey = {
   status: Status;
   finishMessage: string;
   isVisible: boolean;
+  isResultOpen: boolean;
   rewardSetting: RewardConfig;
   sections: Section[];
 };

--- a/src/components/workbench/types/store.ts
+++ b/src/components/workbench/types/store.ts
@@ -32,6 +32,7 @@ type Store = {
   finishMessage: string;
   status: 'NOT_STARTED' | 'IN_PROGRESS' | 'IN_MODIFICATION' | 'CLOSED';
   isVisible: boolean;
+  isResultOpen: boolean;
 
   // reward
   rewardConfig: RewardConfig;

--- a/src/services/participant/fetch.ts
+++ b/src/services/participant/fetch.ts
@@ -1,9 +1,9 @@
 import { kyWrapper } from '../ky-wrapper';
-import { makeUrl } from '../utils';
+import { makeUrlWithUndefined } from '../utils';
 import type { ParticipantList } from './types';
 
-const getParticipants = async (surveyId: string) => {
-  const URL = makeUrl(['surveys', 'participants', surveyId]);
+const getParticipants = async (surveyId: string, visitorId: string | undefined) => {
+  const URL = makeUrlWithUndefined(['surveys', 'management', 'participants', surveyId], { visitorId });
   return kyWrapper.get<ParticipantList>(URL);
 };
 

--- a/src/services/participant/index.ts
+++ b/src/services/participant/index.ts
@@ -2,13 +2,13 @@ import { useQuery, keepPreviousData } from '@tanstack/react-query';
 import { getParticipants } from '@/services/participant/fetch';
 
 const queryKeys = {
-  participants: (surveyId: string) => ['participants', surveyId],
+  participants: (surveyId: string, visitorId: string | undefined) => ['participants', surveyId, visitorId],
 };
 
-const useParticipants = (surveyId: string) => {
+const useParticipants = (surveyId: string, visitorId: string | undefined) => {
   return useQuery({
-    queryKey: queryKeys.participants(surveyId),
-    queryFn: () => getParticipants(surveyId),
+    queryKey: queryKeys.participants(surveyId, visitorId),
+    queryFn: () => getParticipants(surveyId, visitorId),
     placeholderData: keepPreviousData,
     staleTime: 0,
     gcTime: Infinity,

--- a/src/services/result/fetch.ts
+++ b/src/services/result/fetch.ts
@@ -2,8 +2,8 @@ import { kyWrapper } from '../ky-wrapper';
 import { makeUrlWithUndefined } from '../utils';
 import type { SurveyResult, SurveysResultParams } from './types';
 
-const getResults = async ({ surveyId, resultFilter, participantId }: SurveysResultParams) => {
-  const URL = makeUrlWithUndefined(['surveys', 'result', surveyId], { participantId });
+const getResults = async ({ surveyId, resultFilter, participantId, visitorId }: SurveysResultParams) => {
+  const URL = makeUrlWithUndefined(['surveys', 'management', 'result', surveyId], { participantId, visitorId });
   return kyWrapper.post<SurveyResult>(URL, { json: resultFilter });
 };
 

--- a/src/services/result/index.ts
+++ b/src/services/result/index.ts
@@ -3,23 +3,24 @@ import { getResults } from '@/services/result/fetch';
 import type { ResultFilter } from './types';
 
 const queryKeys = {
-  getResults: (surveyId: string, resultFilter: ResultFilter, participantId: string | undefined) => [
-    'getResults',
-    surveyId,
-    resultFilter,
-    participantId,
-  ],
+  getResults: (
+    surveyId: string,
+    resultFilter: ResultFilter,
+    participantId: string | undefined,
+    visitorId: string | undefined
+  ) => ['getResults', surveyId, resultFilter, participantId, visitorId],
 };
 
 const useSurveyResult = (
   surveyId: string,
   resultFilter: ResultFilter,
   participantId: string | undefined,
+  visitorId: string | undefined,
   options?: { enabled?: boolean }
 ) => {
   return useQuery({
-    queryKey: queryKeys.getResults(surveyId, resultFilter, participantId),
-    queryFn: () => getResults({ surveyId, resultFilter, participantId }),
+    queryKey: queryKeys.getResults(surveyId, resultFilter, participantId, visitorId),
+    queryFn: () => getResults({ surveyId, resultFilter, participantId, visitorId }),
     placeholderData: keepPreviousData,
     enabled: options?.enabled,
   });

--- a/src/services/result/types.ts
+++ b/src/services/result/types.ts
@@ -27,6 +27,7 @@ interface SurveysResultParams {
   surveyId: string;
   resultFilter: ResultFilter;
   participantId: string | undefined;
+  visitorId: string | undefined;
 }
 
 interface ResultFilter {

--- a/src/services/surveys/types.ts
+++ b/src/services/surveys/types.ts
@@ -15,6 +15,7 @@ interface SurveysListResponse {
     targetParticipants: number | null;
     rewardCount: number;
     finishedAt: string | null;
+    isResultOpen: boolean;
     rewards: {
       category: string;
       items: string[];

--- a/src/services/surveys/types.ts
+++ b/src/services/surveys/types.ts
@@ -33,6 +33,7 @@ interface SurveysDetailsResponse {
   currentParticipants: number | null;
   targetParticipants: number | null;
   rewards: Reward[];
+  isResultOpen: boolean;
 }
 
 type RewardType = 'NO_REWARD' | 'SELF_MANAGEMENT' | 'IMMEDIATE_DRAW';


### PR DESCRIPTION
## 📢 설명
- 설문에 참여한 뒤 해당 설문의 통계를 확인할 수 있는 기능 개발
- 설문 제작 페이지의 첫 번째 탭에 설문 통계 공개 옵션 체크 박스 추가
- 메인 페이지, 설문 상세 페이지에 통계 공개 설문 표시
- 설문 참여 후 통계 공개 설문인 경우 설문 통계 보기 버튼 활성화
- 설문 관리 페이지(management)에 isGuest 쿼리스트링을 받아서 게스트용 관리페이지와 제작자용 관리페이지 구분
- 수정된 API 엔드포인트에 맞게 여러 부분들 수정
- 자세한 내용은 링크 참조: https://hunhui.notion.site/120aa2ba233d8026ae33e947f0eea2a7?pvs=4

## ✅ 체크 리스트 - [백엔드 199번 브랜치](https://github.com/SUIN-BUNDANG-LINE/Backend/pull/94)와 연계해서 진행
- [x] 오프라인으로 리뷰 진행
