### PR TITLE
[SBL-231] 차트 이미지를 클립보드에 복사하는 버튼 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "chart.js": "^4.4.4",
         "chartjs-plugin-datalabels": "^2.2.0",
         "cookies-next": "^4.2.1",
+        "html2canvas": "^1.4.1",
         "immer": "^10.1.1",
         "jsonwebtoken": "^9.0.2",
         "ky": "^1.5.0",
@@ -1690,6 +1691,14 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -2115,6 +2124,14 @@
       "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-to-react-native": {
@@ -3733,6 +3750,18 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/human-signals": {
@@ -6665,6 +6694,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -6912,6 +6949,14 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/uuid": {
       "version": "10.0.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "chart.js": "^4.4.4",
     "chartjs-plugin-datalabels": "^2.2.0",
     "cookies-next": "^4.2.1",
+    "html2canvas": "^1.4.1",
     "immer": "^10.1.1",
     "jsonwebtoken": "^9.0.2",
     "ky": "^1.5.0",

--- a/src/components/management/result/QuestionResultViewer.module.css
+++ b/src/components/management/result/QuestionResultViewer.module.css
@@ -1,9 +1,26 @@
 .questionContainer {
+  position: relative;
   background-color: #ffffff;
   /* box-shadow: -6px 0px 0px 0px rgb(255, 213, 33); */
   border-radius: 4px;
   padding: 20px;
   margin-bottom: 20px;
+}
+
+.copyButton {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 18px;
+  color: #5b5b5b;
+  z-index: 1000;
+}
+
+.copyButton:hover {
+  color: #000;
 }
 
 .questionTitle {

--- a/src/components/management/result/QuestionResultViewer.module.css
+++ b/src/components/management/result/QuestionResultViewer.module.css
@@ -9,7 +9,7 @@
 
 .copyButton {
   position: absolute;
-  top: 10px;
+  top: 26px;
   right: 10px;
   background: none;
   border: none;
@@ -21,6 +21,40 @@
 
 .copyButton:hover {
   color: #000;
+}
+
+.submit {
+  padding: 0;
+  border: none;
+  cursor: pointer;
+  background-color: transparent;
+}
+
+.submitInner {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  color: var(--gray-d);
+  transition: all 0.3s cubic-bezier(0.165, 0.84, 0.44, 1);
+  border-radius: 4px;
+  background-color: transparent;
+  cursor: pointer;
+  padding: 10px 14px;
+}
+
+.submit:not(:disabled):hover .submitInner {
+  background-color: var(--gray-ml);
+  transform: translateY(-2px);
+  box-shadow: var(--box-shadow);
+  color: #000;
+}
+
+.submit:disabled:hover .submitInner {
+  color: var(--gray);
+  cursor: wait;
 }
 
 .questionTitle {

--- a/src/components/management/result/QuestionResultViewer.tsx
+++ b/src/components/management/result/QuestionResultViewer.tsx
@@ -2,6 +2,7 @@ import { useRef } from 'react';
 import { QuestionResult } from '@/services/result/types';
 import { FaUsers, FaClipboard } from 'react-icons/fa';
 import html2canvas from 'html2canvas';
+import { showToast } from '@/utils/toast';
 import styles from './QuestionResultViewer.module.css';
 import PieChartComponent from './PieChartComponent';
 import TextResponseList from './TextResponseList';
@@ -59,9 +60,9 @@ export default function QuestionResultViewer({ questionResult }: { questionResul
                 [blob.type]: blob,
               }),
             ]);
-            alert('이미지가 클립보드에 복사되었습니다.');
+            showToast('success', '이미지가 클립보드에 복사되었습니다.');
           } catch (err) {
-            console.error('클립보드 복사 중 오류 발생:', err);
+            showToast('error', '클립보드 복사 중 오류가 발생했습니다.');
           }
         }
       });

--- a/src/components/management/result/QuestionResultViewer.tsx
+++ b/src/components/management/result/QuestionResultViewer.tsx
@@ -1,15 +1,16 @@
 import { useRef } from 'react';
 import { QuestionResult } from '@/services/result/types';
-import { FaUsers, FaClipboard } from 'react-icons/fa';
+import { FaUsers } from 'react-icons/fa';
 import html2canvas from 'html2canvas';
 import { showToast } from '@/utils/toast';
+import { writeClipboard } from '@/utils/misc';
 import styles from './QuestionResultViewer.module.css';
 import PieChartComponent from './PieChartComponent';
 import TextResponseList from './TextResponseList';
 import Svg from '../misc/Svg';
 
 export default function QuestionResultViewer({ questionResult }: { questionResult: QuestionResult }) {
-  const { id, title, responses, participantCount, type } = questionResult;
+  const { title, responses, participantCount, type } = questionResult;
   const componentRef = useRef<HTMLDivElement>(null);
 
   const fields = [
@@ -34,6 +35,11 @@ export default function QuestionResultViewer({ questionResult }: { questionResul
   };
 
   const handleCopyToClipboard = async () => {
+    if (type === 'TEXT_RESPONSE') {
+      if (responses) writeClipboard(responses.map((i) => i.content).join('\n'));
+      return;
+    }
+
     if (componentRef.current) {
       const copyButton = componentRef.current.querySelector(`.${styles.copyButton}`) as HTMLButtonElement;
       if (copyButton) {
@@ -70,10 +76,12 @@ export default function QuestionResultViewer({ questionResult }: { questionResul
   };
 
   return (
-    <div className={styles.questionContainer} id={`question-result-${id}`} ref={componentRef}>
-      <button type="button" aria-label="클립보드에 복사" className={styles.copyButton} onClick={handleCopyToClipboard}>
-        <FaClipboard />
-      </button>
+    <div className={styles.questionContainer} ref={componentRef}>
+      <div className={styles.copyButton}>
+        <button type="button" className={styles.submit} onClick={handleCopyToClipboard}>
+          <div className={styles.submitInner}>복사</div>
+        </button>
+      </div>
       <h2 className={styles.questionTitle}>{title}</h2>
       <div className={styles.questionInfo}>
         <div className={styles.questionType}>


### PR DESCRIPTION
## 📢 설명
![image](https://github.com/user-attachments/assets/a2bed53b-5ac9-4367-b1e6-bd135653b306)
- 설문 관리 페이지의 통계 보기 탭에서 각 질문에 복사 버튼 추가
- 주관식의 경우 모든 응답을 텍스트로 클립보드에 복사
- 객관식의 경우 차트 컴포넌트의 이미지를 클립보드에 복사

## ✅ 체크 리스트
- [x] 오프라인 리뷰 진행
